### PR TITLE
json2cbor: Initialize index before "for scope"

### DIFF
--- a/tools/json2cbor/json2cbor.c
+++ b/tools/json2cbor/json2cbor.c
@@ -149,12 +149,13 @@ uint8_t *decode_base64url(const char *string, size_t *len)
 
 uint8_t *decode_base16(const char *string, size_t *len)
 {
+    size_t i;
     *len = strlen(string) / 2;
     uint8_t *buffer = malloc(*len);
     if (buffer == NULL)
         return NULL;
 
-    for (size_t i = 0; i < *len; ++i) {
+    for (i = 0; i < *len; ++i) {
         char c = string[i * 2];
         if (c >= '0' && c <= '9') {
             buffer[i] = (c - '0') << 4;


### PR DESCRIPTION
Observed issue on earlier version:

  json2cbor.c:157:5: \
  error: for loop initial declarations are only allowed in C99 mode

Note, it's not manatory for current master branch
since build script already sets the c99 flag,
but it won't cause any harm.

Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>