### PR TITLE
Make sure that -fPIC objects are removed in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ uninstall:
 
 mostlyclean:
 	$(RM) $(TINYCBOR_SOURCES:.c=.o)
+	$(RM) $(TINYCBOR_SOURCES:.c=.pic.o)
 	$(RM) $(CBORDUMP_SOURCES:.c=.o)
 
 clean: mostlyclean


### PR DESCRIPTION
We were leaving the .pic.o files behind

@CoRfr 