### PR TITLE
Fix MSVC build: cborvalidation.obj wasn't added to the library

### DIFF
--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -8,14 +8,15 @@ TINYCBOR_SOURCES = \
 	src\cborparser.c \
 	src\cborparser_dup_string.c \
 	src\cborpretty.c \
-	src/cborvalidation.c
+	src\cborvalidation.c
 TINYCBOR_OBJS = \
 	src\cborerrorstrings.obj \
 	src\cborencoder.obj \
 	src\cborencoder_close_container_checked.obj \
 	src\cborparser.obj \
 	src\cborparser_dup_string.obj \
-	src\cborpretty.obj
+	src\cborpretty.obj \
+	src\cborvalidation.obj
 
 all: lib\tinycbor.lib
 check: tests\Makefile lib\tinycbor.lib


### PR DESCRIPTION
My own fault....