### PR TITLE
Fix compiler warnings for tst_cpp

### DIFF
--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -22,8 +22,12 @@
 **
 ****************************************************************************/
 
+#ifndef _BSD_SOURCE
 #define _BSD_SOURCE 1
+#endif
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE 1
+#endif
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -22,8 +22,12 @@
 **
 ****************************************************************************/
 
+#ifndef _BSD_SOURCE
 #define _BSD_SOURCE 1
+#endif
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE 1
+#endif
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif

--- a/src/cborparser_dup_string.c
+++ b/src/cborparser_dup_string.c
@@ -22,8 +22,12 @@
 **
 ****************************************************************************/
 
+#ifndef _BSD_SOURCE
 #define _BSD_SOURCE 1
+#endif
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE 1
+#endif
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif


### PR DESCRIPTION
- The defines(_BSD_SOURCE, _DEFAULT_SOURCE) were getting defined in multiple source files 
   generating warnings
- Solution is to conditionally define the above
- These were seen when making changes for [Tinycbor mynewt upstream #83](https://github.com/intel/tinycbor/pull/83)

```
9.2/mkspecs/macx-clang -F/usr/local/Cellar/qt/5.9.2/lib -o tst_cpp.o tst_cpp.cpp
In file included from tst_cpp.cpp:27:
./../../src/cborencoder.c:25:9: warning: '_BSD_SOURCE' macro redefined [-Wmacro-redefined]
#define _BSD_SOURCE 1
        ^
../../src/compilersupport_p.h:35:11: note: previous definition is here
#  define _BSD_SOURCE
          ^
In file included from tst_cpp.cpp:27:
./../../src/cborencoder.c:26:9: warning: '_DEFAULT_SOURCE' macro redefined [-Wmacro-redefined]
#define _DEFAULT_SOURCE 1
        ^
../../src/compilersupport_p.h:38:11: note: previous definition is here
#  define _DEFAULT_SOURCE
          ^
2 warnings generated.
```