### PR TITLE
Encoder: Fix the returning of OOM errors in closing containers

### DIFF
--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -535,7 +535,7 @@ CborError cbor_encoder_close_container(CborEncoder *encoder, const CborEncoder *
     encoder->end = containerEncoder->end;
     if (containerEncoder->flags & CborIteratorFlag_UnknownLength)
         return append_byte_to_buffer(encoder, BreakByte);
-    if (encoder->end)
+    if (!encoder->end)
         return CborErrorOutOfMemory;    /* keep the state */
     return CborNoError;
 }

--- a/tests/encoder/tst_encoder.cpp
+++ b/tests/encoder/tst_encoder.cpp
@@ -225,7 +225,7 @@ CborError encodeVariant(CborEncoder *encoder, const QVariant &v)
                 if (err && !isOomError(err))
                     return err;
             }
-            return static_cast<CborError>(err | cbor_encoder_close_container_checked(encoder, &sub));
+            return cbor_encoder_close_container_checked(encoder, &sub);
         }
         if (type == qMetaTypeId<Map>() || type == qMetaTypeId<IndeterminateLengthMap>()) {
             CborEncoder sub;
@@ -246,7 +246,7 @@ CborError encodeVariant(CborEncoder *encoder, const QVariant &v)
                 if (err && !isOomError(err))
                     return err;
             }
-            return (CborError)(err | cbor_encoder_close_container_checked(encoder, &sub));
+            return cbor_encoder_close_container_checked(encoder, &sub);
         }
     }
     return CborErrorUnknownType;


### PR DESCRIPTION
Conditional added by 3369dd1f017598f74c3f6f36591505377d72bd9d was
inverted.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>