### PR TITLE
Validation: make sure that it compiles in C++ mode too

### DIFF
--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -355,7 +355,7 @@ static inline CborError validate_tag(CborValue *it, CborTag tag, int flags, int 
 
         /* correct Integer so it's not zero */
         if (type == CborIntegerType)
-            ++type;
+            type = (CborType)(type + 1);
 
         while (allowedTypes) {
             if ((uint8_t)(allowedTypes & 0xff) == type)

--- a/tests/cpp/tst_cpp.cpp
+++ b/tests/cpp/tst_cpp.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2015 Intel Corporation
+** Copyright (C) 2017 Intel Corporation
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to deal
@@ -23,9 +23,10 @@
 ****************************************************************************/
 
 #include "../../src/cborencoder.c"
+#include "../../src/cborerrorstrings.c"
 #include "../../src/cborparser.c"
 #include "../../src/cborparser_dup_string.c"
-#include "../../src/cborerrorstrings.c"
+#include "../../src/cborvalidation.c"
 
 #include <QtTest>
 


### PR DESCRIPTION
Like the rest of our parser and encoder, it's useful to be #include'd in
C++ souces.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>