### PR TITLE
Pretty: limit the number of recursions, like the Parser

### DIFF
--- a/src/cborinternal_p.h
+++ b/src/cborinternal_p.h
@@ -31,6 +31,10 @@
 #  define CBOR_INTERNAL_API
 #endif
 
+#ifndef CBOR_PARSER_MAX_RECURSIONS
+#  define CBOR_PARSER_MAX_RECURSIONS 1024
+#endif
+
 /*
  * CBOR Major types
  * Encoded in the high 3 bits of the descriptor byte

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -38,10 +38,6 @@
 
 #include <string.h>
 
-#ifndef CBOR_PARSER_MAX_RECURSIONS
-#  define CBOR_PARSER_MAX_RECURSIONS 1024
-#endif
-
 /**
  * \defgroup CborParsing Parsing CBOR streams
  * \brief Group of functions used to parse CBOR streams.


### PR DESCRIPTION
The pretty-dumper code did not have a limit, assuming that the input had
been validated beforehand, so if the nesting was too deep, one would
have got an error before getting to the dumper.

However, it's not inconceivable that someone adds a logger code to a
packet a bit too early. So let's be defensive and apply the limiter here
too.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>