### PR TITLE
Parser: set *len = 0 in the last string chunk

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -1021,6 +1021,7 @@ static CborError get_string_chunk(CborValue *it, const void **bufferptr, size_t 
         ++it->ptr;
 last_chunk:
         *bufferptr = NULL;
+        *len = 0;
         return preparse_next_value(it);
     } else if ((uint8_t)(*it->ptr & MajorTypeMask) == it->type) {
         err = extract_length(it->parser, &it->ptr, len);


### PR DESCRIPTION
Probably a good idea anyway, plus solves a false positive warning:
```
 src/compilersupport_p.h:192:34: error: ‘chunkLen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return __builtin_add_overflow(v1, v2, r);
            ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
 src/cborparser.c:1163:16: note: ‘chunkLen’ was declared here
         size_t chunkLen = chunkLen;
                ^~~~~~~~
```
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>