### PR TITLE
Only #include <assert.h> if assert isn't yet defined

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -25,7 +25,9 @@
 #ifndef CBOR_H
 #define CBOR_H
 
+#ifndef assert
 #include <assert.h>
+#endif
 #include <limits.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -33,7 +33,9 @@
 #ifndef _DEFAULT_SOURCE
 #  define _DEFAULT_SOURCE
 #endif
-#include <assert.h>
+#ifndef assert
+#  include <assert.h>
+#endif
 #include <float.h>
 #include <math.h>
 #include <stddef.h>


### PR DESCRIPTION
The C standard requires every the macro to be redefined every time that
<assert.h> is included. It does so you can change NDEBUG from one

But that also means a wrapper couldn't #define assert to their own
macro. So stop overriding.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>