### PR TITLE
Encoder: Change the way we reckon the number of items added

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -209,7 +209,7 @@ struct CborEncoder
         ptrdiff_t bytes_needed;
     } data;
     const uint8_t *end;
-    size_t added;
+    size_t remaining;
     int flags;
 };
 typedef struct CborEncoder CborEncoder;

--- a/src/cborencoder_close_container_checked.c
+++ b/src/cborencoder_close_container_checked.c
@@ -29,8 +29,6 @@
 #endif
 
 #include "cbor.h"
-#include "cborinternal_p.h"
-#include "compilersupport_p.h"
 
 /**
  * \addtogroup CborEncoding
@@ -38,40 +36,22 @@
  */
 
 /**
+ * @deprecated
  *
  * Closes the CBOR container (array or map) provided by \a containerEncoder and
  * updates the CBOR stream provided by \a encoder. Both parameters must be the
  * same as were passed to cbor_encoder_create_array() or
  * cbor_encoder_create_map().
  *
- * Unlike cbor_encoder_close_container(), this function checks that the number
- * of items (or pair of items, in the case of a map) was correct. If the number
- * of items inserted does not match the length originally passed to
- * cbor_encoder_create_array() or cbor_encoder_create_map(), this function
- * returns either CborErrorTooFewItems or CborErrorTooManyItems.
+ * Prior to version 0.5, cbor_encoder_close_container() did not check the
+ * number of items added. Since that version, it does and now
+ * cbor_encoder_close_container_checked() is no longer needed.
  *
  * \sa cbor_encoder_create_array(), cbor_encoder_create_map()
  */
 CborError cbor_encoder_close_container_checked(CborEncoder *encoder, const CborEncoder *containerEncoder)
 {
-    const uint8_t *ptr = encoder->data.ptr;
-    CborError err = cbor_encoder_close_container(encoder, containerEncoder);
-    if (containerEncoder->flags & CborIteratorFlag_UnknownLength || encoder->end == NULL)
-        return err;
-
-    /* check what the original length was */
-    uint64_t actually_added;
-    err = _cbor_value_extract_number(&ptr, encoder->data.ptr, &actually_added);
-    if (err)
-        return err;
-
-    if (containerEncoder->flags & CborIteratorFlag_ContainerIsMap) {
-        if (actually_added > SIZE_MAX / 2)
-            return CborErrorDataTooLarge;
-        actually_added *= 2;
-    }
-    return actually_added == containerEncoder->added ? CborNoError :
-           actually_added < containerEncoder->added ? CborErrorTooManyItems : CborErrorTooFewItems;
+    return cbor_encoder_close_container(encoder, containerEncoder);
 }
 
 /** @} */

--- a/tests/encoder/tst_encoder.cpp
+++ b/tests/encoder/tst_encoder.cpp
@@ -276,7 +276,7 @@ void compare(const QVariant &input, const QByteArray &output)
     cbor_encoder_init(&encoder, bufptr, buffer.length(), 0);
 
     QCOMPARE(encodeVariant(&encoder, input), CborNoError);
-    QCOMPARE(encoder.added, size_t(1));
+    QCOMPARE(encoder.remaining, size_t(1));
     QCOMPARE(cbor_encoder_get_extra_bytes_needed(&encoder), size_t(0));
 
     buffer.resize(int(cbor_encoder_get_buffer_size(&encoder, bufptr)));
@@ -642,7 +642,7 @@ void tst_Encoder::tooShortArrays()
     cbor_encoder_init(&encoder, reinterpret_cast<quint8 *>(buffer.data()), buffer.length(), 0);
     QCOMPARE(cbor_encoder_create_array(&encoder, &container, 2), CborNoError);
     QCOMPARE(encodeVariant(&container, input), CborNoError);
-    QCOMPARE(container.added, size_t(1));
+    QCOMPARE(container.remaining, size_t(2));
     QCOMPARE(cbor_encoder_close_container_checked(&encoder, &container), CborErrorTooFewItems);
 }
 
@@ -656,7 +656,7 @@ void tst_Encoder::tooShortMaps()
     cbor_encoder_init(&encoder, reinterpret_cast<quint8 *>(buffer.data()), buffer.length(), 0);
     QCOMPARE(cbor_encoder_create_map(&encoder, &container, 2), CborNoError);
     QCOMPARE(encodeVariant(&container, input), CborNoError);
-    QCOMPARE(container.added, size_t(1));
+    QCOMPARE(container.remaining, size_t(4));
     QCOMPARE(cbor_encoder_close_container_checked(&encoder, &container), CborErrorTooFewItems);
 }
 
@@ -671,7 +671,7 @@ void tst_Encoder::tooBigArrays()
     QCOMPARE(cbor_encoder_create_array(&encoder, &container, 1), CborNoError);
     QCOMPARE(encodeVariant(&container, input), CborNoError);
     QCOMPARE(encodeVariant(&container, input), CborNoError);
-    QCOMPARE(container.added, size_t(2));
+    QCOMPARE(container.remaining, size_t(0));
     QCOMPARE(cbor_encoder_close_container_checked(&encoder, &container), CborErrorTooManyItems);
 }
 
@@ -687,7 +687,7 @@ void tst_Encoder::tooBigMaps()
     QCOMPARE(encodeVariant(&container, input), CborNoError);
     QCOMPARE(encodeVariant(&container, input), CborNoError);
     QCOMPARE(encodeVariant(&container, input), CborNoError);
-    QCOMPARE(container.added, size_t(3));
+    QCOMPARE(container.remaining, size_t(0));
     QCOMPARE(cbor_encoder_close_container_checked(&encoder, &container), CborErrorTooManyItems);
 }
 


### PR DESCRIPTION
Instead of counting forward the number of items added, which meant we
couldn't know in cbot_encoder_close_container() whether we had added
enough, let's count backwards. The number is offset by 1 so we should be
at 1 if we added exactly as many items as we had expected to. Zero means
we added too many. Any other number means we added too few.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>