### PR TITLE
JSON: Change the first number of the JSON conversion errors

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -191,7 +191,7 @@ typedef enum CborError {
     CborErrorUnsupportedType,
 
     /* errors in converting to JSON */
-    CborErrorJsonObjectKeyIsAggregate,
+    CborErrorJsonObjectKeyIsAggregate = 1280,
     CborErrorJsonObjectKeyNotString,
     CborErrorJsonNotImplemented,
 


### PR DESCRIPTION
This gives us a little more room to add validation errors when we have
to keep binary compatibility.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>