### PR TITLE
json2cbor: don't crash if realloc() returns false

### DIFF
--- a/tools/json2cbor/json2cbor.c
+++ b/tools/json2cbor/json2cbor.c
@@ -448,8 +448,10 @@ int main(int argc, char **argv)
         buffer = NULL;
         do {    // it the hard way
             buffer = realloc(buffer, buffersize + chunk);
-            if (buffer == NULL)
+            if (buffer == NULL) {
                 perror("malloc");
+                return EXIT_FAILURE;
+            }
 
             buffersize += fread(buffer + buffersize, 1, chunk, in);
         } while (!feof(in) && !ferror(in));


### PR DESCRIPTION
perror() doesn't exist. It's not like Perl's die().

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>