### PR TITLE
Validator: simplify (and correct) the map sorting verification

### DIFF
--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -472,29 +472,16 @@ static CborError validate_container(CborValue *it, int containerType, int flags,
 
         if (flags & CborValidateMapIsSorted) {
             if (previous) {
-                uint64_t len1, len2;
-                const uint8_t *ptr;
+                size_t bytelen1 = (size_t)(previous_end - previous);
+                size_t bytelen2 = (size_t)(it->ptr - current);
+                int r = memcmp(previous, current, bytelen1 <= bytelen2 ? bytelen1 : bytelen2);
 
-                /* extract the two lengths */
-                ptr = previous;
-                _cbor_value_extract_number(&ptr, it->parser->end, &len1);
-                ptr = current;
-                _cbor_value_extract_number(&ptr, it->parser->end, &len2);
-
-                if (len1 > len2)
+                if (r == 0 && bytelen1 != bytelen2)
+                    r = bytelen1 < bytelen2 ? -1 : +1;
+                if (r > 0)
                     return CborErrorMapNotSorted;
-                if (len1 == len2) {
-                    size_t bytelen1 = (size_t)(previous_end - previous);
-                    size_t bytelen2 = (size_t)(it->ptr - current);
-                    int r = memcmp(previous, current, bytelen1 <= bytelen2 ? bytelen1 : bytelen2);
-
-                    if (r == 0 && bytelen1 != bytelen2)
-                        r = bytelen1 < bytelen2 ? -1 : +1;
-                    if (r > 0)
-                        return CborErrorMapNotSorted;
-                    if (r == 0 && (flags & CborValidateMapKeysAreUnique) == CborValidateMapKeysAreUnique)
-                        return CborErrorMapKeysNotUnique;
-                }
+                if (r == 0 && (flags & CborValidateMapKeysAreUnique) == CborValidateMapKeysAreUnique)
+                    return CborErrorMapKeysNotUnique;
             }
 
             previous = current;


### PR DESCRIPTION
We don't need to compare the map lengths directly. The memcmp is
sufficient, since the source data is big endian.

Of course, verifying for sorting requires the map has known length.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
