### PR TITLE
Update gcc flags to enable building json2cbor with gcc 4.4.7 (standard in CentOS 6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ tag: distcheck
 .SECONDARY:
 
 cflags := $(CPPFLAGS) -I$(SRCDIR)src
-cflags += -std=c99 $(CFLAGS)
+cflags += -std=gnu99 $(CFLAGS)
 %.o: %.c
 	@test -d $(@D) || $(MKDIR) $(@D)
 	$(CC) $(cflags) $($(basename $(notdir $@))_CCFLAGS) -c -o $@ $<


### PR DESCRIPTION
Fixes https://github.com/intel/tinycbor/issues/120