### PR TITLE
Incomplete input results in invalid assert

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -326,7 +326,9 @@ static CborError advance_internal(CborValue *it)
 {
     uint64_t length;
     CborError err = _cbor_value_extract_number(&it->ptr, it->parser->end, &length);
-    cbor_assert(err == CborNoError);
+    
+    if (err)
+	    return err;
 
     if (it->type == CborByteStringType || it->type == CborTextStringType) {
         cbor_assert(length == (size_t)length);


### PR DESCRIPTION
Currently, tinycbor does not allow to hand over incomplete numeric Cbor values. Due to the assert checking for an error while extracting a number from the input, the parsing process globally fails. Instead of checking the error via assert, it should be propagated back to the caller.