### PR TITLE
validation: Fix brace mismatch with float disabled

### DIFF
--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -623,8 +623,8 @@ static CborError validate_value(CborValue *it, int flags, int recursionLeft)
         if (err)
             return err;
         break;
-    }
 #endif /* !CBOR_NO_FLOATING_POINT */
+    }
 
     case CborInvalidType:
         return CborErrorUnknownType;


### PR DESCRIPTION
Compiling without floating point support causes compilation errors due to a missing closing brace in the case statement. This PR fixes that by moving the closing brace outside the `#ifdef`