### PR TITLE
Change flag type to uint32_t for parser validation flags

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -276,7 +276,7 @@ enum CborParserIteratorFlags
 struct CborParser
 {
     const uint8_t *end;
-    int flags;
+    uint32_t flags;
 };
 typedef struct CborParser CborParser;
 
@@ -291,7 +291,7 @@ struct CborValue
 };
 typedef struct CborValue CborValue;
 
-CBOR_API CborError cbor_parser_init(const uint8_t *buffer, size_t size, int flags, CborParser *parser, CborValue *it);
+CBOR_API CborError cbor_parser_init(const uint8_t *buffer, size_t size, uint32_t flags, CborParser *parser, CborValue *it);
 
 CBOR_API CborError cbor_value_validate_basic(const CborValue *it);
 
@@ -556,7 +556,7 @@ enum CborValidationFlags {
     CborValidateBasic                       = 0
 };
 
-CBOR_API CborError cbor_value_validate(const CborValue *it, int flags);
+CBOR_API CborError cbor_value_validate(const CborValue *it, uint32_t flags);
 
 /* Human-readable (dump) API */
 

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -372,7 +372,7 @@ uint64_t _cbor_value_decode_int64_internal(const CborValue *value)
  * threads iterating at the same time, but the object can be copied so multiple
  * threads can iterate.
  */
-CborError cbor_parser_init(const uint8_t *buffer, size_t size, int flags, CborParser *parser, CborValue *it)
+CborError cbor_parser_init(const uint8_t *buffer, size_t size, uint32_t flags, CborParser *parser, CborValue *it)
 {
     memset(parser, 0, sizeof(*parser));
     parser->end = buffer + size;

--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -265,7 +265,7 @@ static const struct KnownTagData knownTagData[] = {
     { 55799, 0U }
 };
 
-static CborError validate_value(CborValue *it, int flags, int recursionLeft);
+static CborError validate_value(CborValue *it, uint32_t flags, int recursionLeft);
 
 static inline CborError validate_utf8_string(const void *ptr, size_t n)
 {
@@ -279,7 +279,7 @@ static inline CborError validate_utf8_string(const void *ptr, size_t n)
     return CborNoError;
 }
 
-static inline CborError validate_simple_type(uint8_t simple_type, int flags)
+static inline CborError validate_simple_type(uint8_t simple_type, uint32_t flags)
 {
     /* At current time, all known simple types are those from RFC 7049,
      * which are parsed by the parser into different CBOR types.
@@ -290,7 +290,7 @@ static inline CborError validate_simple_type(uint8_t simple_type, int flags)
                 CborErrorUnknownSimpleType : CborNoError;
 }
 
-static inline CborError validate_number(const CborValue *it, CborType type, int flags)
+static inline CborError validate_number(const CborValue *it, CborType type, uint32_t flags)
 {
     CborError err = CborNoError;
     const uint8_t *ptr = it->ptr;
@@ -320,7 +320,7 @@ static inline CborError validate_number(const CborValue *it, CborType type, int 
     return CborNoError;
 }
 
-static inline CborError validate_tag(CborValue *it, CborTag tag, int flags, int recursionLeft)
+static inline CborError validate_tag(CborValue *it, CborTag tag, uint32_t flags, int recursionLeft)
 {
     CborType type = cbor_value_get_type(it);
     const size_t knownTagCount = sizeof(knownTagData) / sizeof(knownTagData[0]);
@@ -373,7 +373,7 @@ static inline CborError validate_tag(CborValue *it, CborTag tag, int flags, int 
 }
 
 #ifndef CBOR_NO_FLOATING_POINT
-static inline CborError validate_floating_point(CborValue *it, CborType type, int flags)
+static inline CborError validate_floating_point(CborValue *it, CborType type, uint32_t flags)
 {
     CborError err;
     double val;
@@ -435,7 +435,7 @@ static inline CborError validate_floating_point(CborValue *it, CborType type, in
 }
 #endif
 
-static CborError validate_container(CborValue *it, int containerType, int flags, int recursionLeft)
+static CborError validate_container(CborValue *it, int containerType, uint32_t flags, int recursionLeft)
 {
     CborError err;
     const uint8_t *previous = NULL;
@@ -509,7 +509,7 @@ static CborError validate_container(CborValue *it, int containerType, int flags,
     return CborNoError;
 }
 
-static CborError validate_value(CborValue *it, int flags, int recursionLeft)
+static CborError validate_value(CborValue *it, uint32_t flags, int recursionLeft)
 {
     CborError err;
     CborType type = cbor_value_get_type(it);
@@ -648,7 +648,7 @@ static CborError validate_value(CborValue *it, int flags, int recursionLeft)
  *
  * \sa CborValidationFlags, cbor_value_validate_basic(), cbor_value_advance()
  */
-CborError cbor_value_validate(const CborValue *it, int flags)
+CborError cbor_value_validate(const CborValue *it, uint32_t flags)
 {
     CborValue value = *it;
     CborError err = validate_value(&value, flags, CBOR_PARSER_MAX_RECURSIONS);


### PR DESCRIPTION
On architectures where `int` is 16 bits wide (AVR/arduino) gcc complains about possible overflow caused by the parser validation flags.

This PR changes the flag argument when used for the validation flags to uint32_t so that the enum doesn't cause overflows on any architecture.

I hope I didn't miss any places where the data type has to be changed :)