### PR TITLE
Add more byte order detection code

### DIFF
--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -151,12 +151,17 @@
 /* ntohll isn't usually defined */
 #  ifndef ntohll
 #    if (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || \
-    defined(__ARMEB__) || defined(__MIPSEB__) || defined(__sparc__)
+    (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN) || \
+    (defined(BYTE_ORDER) && defined(BIG_ENDIAN) && BYTE_ORDER == BIG_ENDIAN) || \
+    (defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN)) || (defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)) || \
+    defined(__ARMEB__) || defined(__MIPSEB__) || defined(__s390__) || defined(__sparc__)
 #      define ntohll
 #      define htonll
 #    elif (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
-    defined(__ARMEL__) || defined(__i386) || defined(__i386__) || defined(__x86_64) || defined(__x86_64__) || \
-    defined(__amd64) || defined(__MIPSEL__)
+    (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN) || \
+    (defined(BYTE_ORDER) && defined(LITTLE_ENDIAN) && BYTE_ORDER == LITTLE_ENDIAN) || \
+    defined(_LITTLE_ENDIAN) || defined(__LITTLE_ENDIAN__) || defined(__ARMEL__) || defined(__MIPSEL__) || \
+    defined(__i386) || defined(__i386__) || defined(__x86_64) || defined(__x86_64__) || defined(__amd64)
 #      define ntohll(x)       ((ntohl((uint32_t)(x)) * UINT64_C(0x100000000)) + (ntohl((x) >> 32)))
 #      define htonll          ntohll
 #    else


### PR DESCRIPTION
Suggested in https://sourceforge.net/p/predef/wiki/Endianness/ and also
found by looking into glibc's <endian.h>. Plus some recommendation from
other people.

This fixed the build on INTEGRITY.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>