### PR TITLE
tizenrt: Prevent missing wint_t

### DIFF
--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -37,6 +37,9 @@
 #  include <assert.h>
 #endif
 #include <float.h>
+#ifdef __TIZENRT__
+#include <wchar.h>
+#endif
 #include <math.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
Observed issue on current TizenRT version:

  arm-none-eabi-gcc -c -o obj/cborencoder.o (...)
  In file included from
  .../gcc-arm-none-eabi-6-2017-q1-update/.../reent.h:15:0,
  from
  .../arm-none-eabi/include/math.h:5,
  from ../../deps/tinycbor/src/compilersupport_p.h:40,
  .../sys/_types.h:168:5: error: unknown type name 'wint_t'
  wint_t __wch;

Bug: https://jira.iotivity.org/projects/LITE/issues/LITE-4?
Change-Id: I9269802eb17a0a5d67d81f7e3cb4af78fc52ad2b
Signed-off-by: Philippe Coval <p.coval@samsung.com>