### PR TITLE
Fix no-FP builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
         - QMAKESPEC=linux-g++
         - EVAL="CC=gcc-7 && CXX=g++-7"
         - CFLAGS="-Os"
+        - LDFLAGS="-Wl,--no-undefined -lm"
         - QMAKEFLAGS="-config release"
     - os: linux
       addons:
@@ -29,9 +30,23 @@ matrix:
         - EVAL="CC=clang-5.0 && CXX=clang++"
         - PATH=$PATH:/usr/local/clang/bin
         - CFLAGS="-Oz"
+        - LDFLAGS="-Wl,--no-undefined -lm"
         - QMAKEFLAGS="-config release"
         - MAKEFLAGS=-s
         - TESTARGS=-silent
+    - os: linux
+      env:
+        - QMAKESPEC=linux-gcc-freestanding
+        - EVAL="CXX=false"
+        - CFLAGS="-ffreestanding -Os"
+        - LDFLAGS="-Wl,--no-undefined -lm"
+    - os: linux
+      env:
+        - QMAKESPEC=linux-gcc-no-math
+        - EVAL="CXX=false && touch src/math.h src/float.h"
+        - CFLAGS="-ffreestanding -DCBOR_NO_FLOATING_POINT -Os"
+        - LDFLAGS="-Wl,--no-undefined"
+        - LDLIBS=""
     - os: osx
       env:
         - QMAKESPEC=macx-clang
@@ -57,10 +72,12 @@ script:
   - make -s clean
   - make -k
         CFLAGS="$CFLAGS -O0 -g"
-  - make
+        LDFLAGS="$LDFLAGS" ${LDLIBS+LDLIBS="$LDLIBS"}
+  - grep -q freestanding-pass .config || make
         QMAKEFLAGS="$QMAKEFLAGS QMAKE_CXX=$CXX"
         tests/Makefile
-  - (cd tests && make check -k
+  - grep -q freestanding-pass .config ||
+        (cd tests && make check -k
         TESTRUNNER=`which valgrind 2>/dev/null`)
   - make -s clean
   - ./scripts/update-docs.sh

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 CFLAGS = -Wall -Wextra
 LDFLAGS_GCSECTIONS = -Wl,--gc-sections
 LDFLAGS += $(if $(gc_sections-pass),$(LDFLAGS_GCSECTIONS))
+LDLIBS = -lm
 
 GIT_ARCHIVE = git archive --prefix="$(PACKAGE)/" -9
 INSTALL = install
@@ -139,16 +140,16 @@ lib/libtinycbor.a: $(TINYCBOR_SOURCES:.c=.o)
 
 lib/libtinycbor.so: $(TINYCBOR_SOURCES:.c=.pic.o)
 	@$(MKDIR) -p lib
-	$(CC) -shared -Wl,-soname,libtinycbor.so.$(SOVERSION) -o lib/libtinycbor.so.$(VERSION) $(LDFLAGS) $^
+	$(CC) -shared -Wl,-soname,libtinycbor.so.$(SOVERSION) -o lib/libtinycbor.so.$(VERSION) $(LDFLAGS) $^ $(LDLIBS)
 	cd lib ; ln -sf libtinycbor.so.$(VERSION) libtinycbor.so ; ln -sf libtinycbor.so.$(VERSION) libtinycbor.so.$(SOVERSION)
 
 bin/cbordump: $(CBORDUMP_SOURCES:.c=.o) $(BINLIBRARY)
 	@$(MKDIR) -p bin
-	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS) -lm
+	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS)
 
 bin/json2cbor: $(JSON2CBOR_SOURCES:.c=.o) $(BINLIBRARY)
 	@$(MKDIR) -p bin
-	$(CC) -o $@ $(LDFLAGS) $^ $(LDFLAGS_CJSON) $(LDLIBS) -lm
+	$(CC) -o $@ $(LDFLAGS) $^ $(LDFLAGS_CJSON) $(LDLIBS)
 
 tinycbor.pc: tinycbor.pc.in
 	$(SED) > $@ < $< \

--- a/Makefile.configure
+++ b/Makefile.configure
@@ -1,5 +1,5 @@
 ALLTESTS = open_memstream funopen fopencookie gc_sections \
-	   system-cjson cjson
+	   system-cjson cjson freestanding
 MAKEFILE := $(lastword $(MAKEFILE_LIST))
 OUT :=
 
@@ -8,6 +8,11 @@ PROGRAM-funopen = extern int funopen(); int main() { return funopen(); }
 PROGRAM-fopencookie = extern int fopencookie(); int main() { return fopencookie(); }
 PROGRAM-gc_sections = int main() {}
 CCFLAGS-gc_sections = -Wl,--gc-sections
+PROGRAM-freestanding  = \#if !defined(__STDC_HOSTED__) || __STDC_HOSTED__-0 == 1\n
+PROGRAM-freestanding += \#error Hosted implementation\n
+PROGRAM-freestanding += \#endif\n
+PROGRAM-freestanding += int main() {}
+CCFLAGS-freestanding = $(CFLAGS)
 
 PROGRAM-cjson  = \#include <stdlib.h>\n
 PROGRAM-cjson += \#include <cjson/cJSON.h>\n

--- a/src/cborinternal_p.h
+++ b/src/cborinternal_p.h
@@ -27,6 +27,75 @@
 
 #include "compilersupport_p.h"
 
+#ifndef CBOR_NO_FLOATING_POINT
+#  include <float.h>
+#  include <math.h>
+#else
+#  ifndef CBOR_NO_HALF_FLOAT_TYPE
+#    define CBOR_NO_HALF_FLOAT_TYPE     1
+#  endif
+#endif
+
+#ifndef CBOR_NO_HALF_FLOAT_TYPE
+#  ifdef __F16C__
+#    include <immintrin.h>
+static inline unsigned short encode_half(double val)
+{
+    return _cvtss_sh((float)val, 3);
+}
+static inline double decode_half(unsigned short half)
+{
+    return _cvtsh_ss(half);
+}
+#  else
+/* software implementation of float-to-fp16 conversions */
+static inline unsigned short encode_half(double val)
+{
+    uint64_t v;
+    int sign, exp, mant;
+    memcpy(&v, &val, sizeof(v));
+    sign = v >> 63 << 15;
+    exp = (v >> 52) & 0x7ff;
+    mant = v << 12 >> 12 >> (53-11);    /* keep only the 11 most significant bits of the mantissa */
+    exp -= 1023;
+    if (exp == 1024) {
+        /* infinity or NaN */
+        exp = 16;
+        mant >>= 1;
+    } else if (exp >= 16) {
+        /* overflow, as largest number */
+        exp = 15;
+        mant = 1023;
+    } else if (exp >= -14) {
+        /* regular normal */
+    } else if (exp >= -24) {
+        /* subnormal */
+        mant |= 1024;
+        mant >>= -(exp + 14);
+        exp = -15;
+    } else {
+        /* underflow, make zero */
+        return 0;
+    }
+
+    /* safe cast here as bit operations above guarantee not to overflow */
+    return (unsigned short)(sign | ((exp + 15) << 10) | mant);
+}
+
+/* this function was copied & adapted from RFC 7049 Appendix D */
+static inline double decode_half(unsigned short half)
+{
+    int exp = (half >> 10) & 0x1f;
+    int mant = half & 0x3ff;
+    double val;
+    if (exp == 0) val = ldexp(mant, -24);
+    else if (exp != 31) val = ldexp(mant + 1024, exp - 25);
+    else val = mant == 0 ? INFINITY : NAN;
+    return half & 0x8000 ? -val : val;
+}
+#  endif
+#endif /* CBOR_NO_HALF_FLOAT_TYPE */
+
 #ifndef CBOR_INTERNAL_API
 #  define CBOR_INTERNAL_API
 #endif

--- a/src/cborpretty.c
+++ b/src/cborpretty.c
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2017 Intel Corporation
+** Copyright (C) 2018 Intel Corporation
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to deal
@@ -35,11 +35,6 @@
 
 #include <inttypes.h>
 #include <string.h>
-
-#ifndef CBOR_NO_FLOATING_POINT
-#  include <float.h>
-#  include <math.h>
-#endif
 
 /**
  * \defgroup CborPretty Converting CBOR to text
@@ -149,6 +144,7 @@
  * \value CborPrettyDefaultFlags                Default conversion flags.
  */
 
+#ifndef CBOR_NO_FLOATING_POINT
 static inline bool convertToUint64(double v, uint64_t *absolute)
 {
     double supremum;
@@ -179,6 +175,7 @@ static inline bool convertToUint64(double v, uint64_t *absolute)
     *absolute = v;
     return *absolute == v;
 }
+#endif
 
 static void printRecursionLimit(CborStreamFunction stream, void *out)
 {

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -36,18 +36,12 @@
 #ifndef assert
 #  include <assert.h>
 #endif
-#include <float.h>
-#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
 #ifndef __cplusplus
 #  include <stdbool.h>
-#endif
-
-#ifdef __F16C__
-#  include <immintrin.h>
 #endif
 
 #if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L || __cpp_static_assert >= 200410
@@ -204,59 +198,6 @@ static inline bool add_check_overflow(size_t v1, size_t v2, size_t *r)
     /* unsigned additions are well-defined */
     *r = v1 + v2;
     return v1 > v1 + v2;
-#endif
-}
-
-static inline unsigned short encode_half(double val)
-{
-#ifdef __F16C__
-    return _cvtss_sh((float)val, 3);
-#else
-    uint64_t v;
-    int sign, exp, mant;
-    memcpy(&v, &val, sizeof(v));
-    sign = v >> 63 << 15;
-    exp = (v >> 52) & 0x7ff;
-    mant = v << 12 >> 12 >> (53-11);    /* keep only the 11 most significant bits of the mantissa */
-    exp -= 1023;
-    if (exp == 1024) {
-        /* infinity or NaN */
-        exp = 16;
-        mant >>= 1;
-    } else if (exp >= 16) {
-        /* overflow, as largest number */
-        exp = 15;
-        mant = 1023;
-    } else if (exp >= -14) {
-        /* regular normal */
-    } else if (exp >= -24) {
-        /* subnormal */
-        mant |= 1024;
-        mant >>= -(exp + 14);
-        exp = -15;
-    } else {
-        /* underflow, make zero */
-        return 0;
-    }
-
-    /* safe cast here as bit operations above guarantee not to overflow */
-    return (unsigned short)(sign | ((exp + 15) << 10) | mant);
-#endif
-}
-
-/* this function was copied & adapted from RFC 7049 Appendix D */
-static inline double decode_half(unsigned short half)
-{
-#ifdef __F16C__
-    return _cvtsh_ss(half);
-#else
-    int exp = (half >> 10) & 0x1f;
-    int mant = half & 0x3ff;
-    double val;
-    if (exp == 0) val = ldexp(mant, -24);
-    else if (exp != 31) val = ldexp(mant + 1024, exp - 25);
-    else val = mant == 0 ? INFINITY : NAN;
-    return half & 0x8000 ? -val : val;
 #endif
 }
 


### PR DESCRIPTION
This commit series fixes TinyCBOR building in both freestanding and no-floating-point environments, adding testing in Travis for those two cases.

@georgen117 @lpereira 