### PR TITLE
fix undefined encode_half in json2cbor

### DIFF
--- a/tools/json2cbor/json2cbor.c
+++ b/tools/json2cbor/json2cbor.c
@@ -25,6 +25,7 @@
 #define _POSIX_C_SOURCE 200809L
 #define _GNU_SOURCE
 #include "cbor.h"
+#include "cborinternal_p.h"
 #include "compilersupport_p.h"
 
 #include <cjson/cJSON.h>


### PR DESCRIPTION
encode_half has been moved from compilersupport_p.h to cborinternal_p.h
in commit bfc40dcf909f1998d7760c2bc0e1409979d3c8cb so include this file
in json2cbor to avoid the following build failure:

/home/buildroot/autobuild/run/instance-0/output/host/bin/microblazeel-linux-gcc -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -I./src -std=gnu99 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os    -c -o tools/json2cbor/json2cbor.o tools/json2cbor/json2cbor.c
tools/json2cbor/json2cbor.c: In function 'decode_json_with_metadata':
tools/json2cbor/json2cbor.c:295:50: warning: implicit declaration of function 'encode_half' [-Wimplicit-function-declaration]
                                          (half = encode_half(v), cbor_encode_half_float(encoder, &half));
                                                  ^~~~~~~~~~~
/home/buildroot/autobuild/run/instance-0/output/host/bin/microblazeel-linux-gcc -o bin/json2cbor  tools/json2cbor/json2cbor.o lib/libtinycbor.so -lcjson -lm
tools/json2cbor/json2cbor.o: In function `decode_json_with_metadata':
(.text+0xe54): undefined reference to `encode_half'
collect2: error: ld returned 1 exit status
Makefile:151: recipe for target 'bin/json2cbor' failed

Fixes:
 - http://autobuild.buildroot.net/results/afd8d24f2a4e501264abff618cf421d4bd088ebf

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>