### PR TITLE
Typo fixed in stdlib fread(...) usage

### DIFF
--- a/examples/simplereader.c
+++ b/examples/simplereader.c
@@ -15,7 +15,7 @@ static uint8_t *readfile(const char *fname, size_t *size)
     if (fstat(fileno(f), &st) == -1)
         return NULL;
     uint8_t *buf = malloc(st.st_size);
-    *size = fread(buf, st.st_size, 1, f);
+    *size = fread(buf, st.st_size, 1, f) == 1 ? st.st_size : 0;
     fclose(f);
     return buf;
 }


### PR DESCRIPTION
fread(...) function returns the number of items read so far, not number of bytes, ergo, reading one st.st_size sized item produces 1 on success and 0 on failure.
Possibly fixing issue #77

Signed-off-by: phirsov <41143811+phirsov@users.noreply.github.com>