### PR TITLE
typo in dumprecursive return type

### DIFF
--- a/examples/simplereader.c
+++ b/examples/simplereader.c
@@ -32,7 +32,7 @@ static void dumpbytes(const uint8_t *buf, size_t len)
         printf("%02X ", *buf++);
 }
 
-static bool dumprecursive(CborValue *it, int nestingLevel)
+static CborError dumprecursive(CborValue *it, int nestingLevel)
 {
     while (!cbor_value_at_end(it)) {
         CborError err;


### PR DESCRIPTION
should be CborError rather than bool