### PR TITLE
Use Qt version provided by Trusty Tahr (Debian Jessie) out-of-the-box

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,32 @@ language: cpp
 matrix:
   include:
     - os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - qtbase5-dev valgrind
+            - g++
+      env:
+        - QMAKESPEC=linux-g++
+        - EVAL="CC=gcc && CXX=g++"
+        - CFLAGS="-Os"
+        - LDFLAGS="-Wl,--no-undefined -lm"
+        - QMAKEFLAGS="-config release"
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - qtbase5-dev valgrind
+            - clang
+      env:
+        - QMAKESPEC=linux-clang
+        - EVAL="CC=clang && CXX=clang++"
+        - CFLAGS="-Oz"
+        - LDFLAGS="-Wl,--no-undefined -lm"
+        - QMAKEFLAGS="-config release"
+    - os: linux
       addons:
         apt:
           sources:
@@ -33,7 +59,6 @@ matrix:
         - LDFLAGS="-Wl,--no-undefined -lm"
         - QMAKEFLAGS="-config release"
         - MAKEFLAGS=-s
-        - TESTARGS=-silent
     - os: linux
       env:
         - QMAKESPEC=linux-gcc-freestanding

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
         - CFLAGS="-Oz"
         - LDFLAGS="-Wl,--no-undefined -lm"
         - QMAKEFLAGS="-config release"
+        - MAKEFLAGS=-s
     - os: linux
       addons:
         apt:

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ tinycbor.pc: tinycbor.pc.in
 		-e 's,@version@,$(VERSION),'
 
 tests/Makefile: tests/tests.pro
-	$(QMAKE) $(QMAKEFLAGS) -o $@ $<
+	cd tests && $(QMAKE) $(QMAKEFLAGS)
 
 $(PACKAGE).tar.gz: | .git
 	GIT_DIR=$(SRCDIR).git $(GIT_ARCHIVE) --format=tar.gz -o "$(PACKAGE).tar.gz" HEAD

--- a/src/cborpretty.c
+++ b/src/cborpretty.c
@@ -526,7 +526,10 @@ static CborError value_to_pretty(CborStreamFunction stream, void *out, CborValue
             err = stream(out, "%s%" PRIu64 ".%s", val < 0 ? "-" : "", ival, suffix);
         } else {
             /* this number is definitely not a 64-bit integer */
-            err = stream(out, "%." DBL_DECIMAL_DIG_STR "g%s", val, suffix);
+            if (fpclassify(val) == FP_NAN)
+                err = stream(out, "nan");
+            else
+                err = stream(out, "%." DBL_DECIMAL_DIG_STR "g%s", val, suffix);
         }
         break;
     }

--- a/tests/encoder/tst_encoder.cpp
+++ b/tests/encoder/tst_encoder.cpp
@@ -151,7 +151,7 @@ typedef QVector<QPair<QVariant, QVariant>> Map;
 Q_DECLARE_METATYPE(Map)
 QVariant make_map(const std::initializer_list<QPair<QVariant, QVariant>> &list)
 {
-    return QVariant::fromValue(Map(list));
+    return QVariant::fromValue(list.size() > 0 ? Map(list) : Map());
 }
 
 struct IndeterminateLengthArray : QVariantList { using QVariantList::QVariantList; };
@@ -161,12 +161,16 @@ Q_DECLARE_METATYPE(IndeterminateLengthMap)
 
 QVariant make_ilarray(const std::initializer_list<QVariant> &list)
 {
-    return QVariant::fromValue(IndeterminateLengthArray(list));
+    return QVariant::fromValue(
+        list.size() > 0 ? IndeterminateLengthArray(list) : IndeterminateLengthArray()
+    );
 }
 
 QVariant make_ilmap(const std::initializer_list<QPair<QVariant, QVariant>> &list)
 {
-    return QVariant::fromValue(IndeterminateLengthMap(list));
+    return QVariant::fromValue(
+        list.size() > 0 ? IndeterminateLengthMap(list) : IndeterminateLengthMap()
+    );
 }
 
 static inline bool isOomError(CborError err)

--- a/tests/parser/tst_parser.cpp
+++ b/tests/parser/tst_parser.cpp
@@ -104,10 +104,30 @@ private slots:
 static CborError qstring_printf(void *out, const char *fmt, ...)
 {
     auto str = static_cast<QString *>(out);
+
     va_list va;
+
     va_start(va, fmt);
-    *str += QString::vasprintf(fmt, va);
+    char c;
+    int buf_size = vsnprintf(&c, 1, fmt, va) + 1;
     va_end(va);
+
+    if (buf_size < 0)
+        return CborErrorIO;
+
+    else if (buf_size == 0)
+        return CborNoError;
+
+    va_start(va, fmt);
+    QByteArray buf(buf_size, '\0');
+    int act_size = vsnprintf(buf.data(), buf.size(), fmt, va);
+    va_end(va);
+
+    if (act_size != buf_size - 1)
+        return CborErrorIO;
+
+    *str += QString::fromLocal8Bit(buf.data(), act_size);
+
     return CborNoError;
 };
 

--- a/tests/parser/tst_parser.cpp
+++ b/tests/parser/tst_parser.cpp
@@ -112,10 +112,10 @@ static CborError qstring_printf(void *out, const char *fmt, ...)
     int buf_size = vsnprintf(&c, 1, fmt, va) + 1;
     va_end(va);
 
-    if (buf_size < 0)
+    if (buf_size <= 0)
         return CborErrorIO;
 
-    else if (buf_size == 0)
+    else if (buf_size == 1)
         return CborNoError;
 
     va_start(va, fmt);


### PR DESCRIPTION
Some people are suspicious about using 3rd-party repositories (PPA's) in their projects. The goal of this PR is to build project with Qt version provided by Ubuntu (Debian) LTS releases repositories out-of-the-box.