### PR TITLE
enhancement #149 implemented: access half-precision floating point data as single float

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ TINYCBOR_FREESTANDING_SOURCES = \
 	src/cborerrorstrings.c \
 	src/cborencoder.c \
 	src/cborencoder_close_container_checked.c \
+	src/cborencoder_float.c \
 	src/cborparser.c \
+	src/cborparser_float.c \
 	src/cborpretty.c \
 #
 CBORDUMP_SOURCES = tools/cbordump/cbordump.c

--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -5,8 +5,10 @@ TINYCBOR_SOURCES = \
 	src\cborerrorstrings.c \
 	src\cborencoder.c \
 	src\cborencoder_close_container_checked.c \
+	src\cborencoder_float.c \
 	src\cborparser.c \
 	src\cborparser_dup_string.c \
+	src\cborparser_float.c \
 	src\cborpretty.c \
 	src\cborpretty_stdio.c \
 	src\cborvalidation.c
@@ -14,8 +16,10 @@ TINYCBOR_OBJS = \
 	src\cborerrorstrings.obj \
 	src\cborencoder.obj \
 	src\cborencoder_close_container_checked.obj \
+	src\cborencoder_float.obj \
 	src\cborparser.obj \
 	src\cborparser_dup_string.obj \
+	src\cborparser_float.obj \
 	src\cborpretty.obj \
 	src\cborpretty_stdio.obj \
 	src\cborvalidation.obj

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -237,6 +237,7 @@ CBOR_INLINE_API CborError cbor_encode_undefined(CborEncoder *encoder)
 
 CBOR_INLINE_API CborError cbor_encode_half_float(CborEncoder *encoder, const void *value)
 { return cbor_encode_floating_point(encoder, CborHalfFloatType, value); }
+CBOR_API CborError cbor_encode_float_as_half_float(CborEncoder *encoder, float value);
 CBOR_INLINE_API CborError cbor_encode_float(CborEncoder *encoder, float value)
 { return cbor_encode_floating_point(encoder, CborFloatType, &value); }
 CBOR_INLINE_API CborError cbor_encode_double(CborEncoder *encoder, double value)
@@ -492,7 +493,9 @@ CBOR_API CborError cbor_value_map_find_value(const CborValue *map, const char *s
 /* Floating point */
 CBOR_INLINE_API bool cbor_value_is_half_float(const CborValue *value)
 { return value->type == CborHalfFloatType; }
+CBOR_PRIVATE_API uint16_t _cbor_value_get_half_float_helper(const CborValue *value);
 CBOR_API CborError cbor_value_get_half_float(const CborValue *value, void *result);
+CBOR_API CborError cbor_value_get_half_float_as_float(const CborValue *value, float *result);
 
 CBOR_INLINE_API bool cbor_value_is_float(const CborValue *value)
 { return value->type == CborFloatType; }

--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -382,7 +382,7 @@ CborError cbor_encode_simple_value(CborEncoder *encoder, uint8_t value)
  * This function is useful for code that needs to pass through floating point
  * values but does not wish to have the actual floating-point code.
  *
- * \sa cbor_encode_half_float, cbor_encode_float, cbor_encode_double
+ * \sa cbor_encode_half_float, cbor_encode_float_as_half_float, cbor_encode_float, cbor_encode_double
  */
 CborError cbor_encode_floating_point(CborEncoder *encoder, CborType fpType, const void *value)
 {
@@ -590,12 +590,24 @@ CborError cbor_encoder_close_container(CborEncoder *encoder, const CborEncoder *
  */
 
 /**
+ * \fn CborError cbor_encode_float_as_half_float(CborEncoder *encoder, float value)
+ *
+ * Convert the IEEE 754 single-precision (32-bit) floating point value \a value
+ * to the IEEE 754 half-precision (16-bit) floating point value and append it
+ * to the CBOR stream provided by \a encoder.
+ * The \a value should be in the range of the IEEE 754 half-precision floating point type,
+ * INFINITY, -INFINITY, or NAN, otherwise the behavior of this function is undefined.
+ *
+ * \sa cbor_encode_floating_point(), cbor_encode_float(), cbor_encode_double()
+ */
+
+/**
  * \fn CborError cbor_encode_float(CborEncoder *encoder, float value)
  *
  * Appends the IEEE 754 single-precision (32-bit) floating point value \a value
  * to the CBOR stream provided by \a encoder.
  *
- * \sa cbor_encode_floating_point(), cbor_encode_half_float(), cbor_encode_double()
+ * \sa cbor_encode_floating_point(), cbor_encode_half_float(), cbor_encode_float_as_half_float(), cbor_encode_double()
  */
 
 /**
@@ -604,7 +616,7 @@ CborError cbor_encoder_close_container(CborEncoder *encoder, const CborEncoder *
  * Appends the IEEE 754 double-precision (64-bit) floating point value \a value
  * to the CBOR stream provided by \a encoder.
  *
- * \sa cbor_encode_floating_point(), cbor_encode_half_float(), cbor_encode_float()
+ * \sa cbor_encode_floating_point(), cbor_encode_half_float(), cbor_encode_float_as_half_float(), cbor_encode_float()
  */
 
 /**

--- a/src/cborencoder_float.c
+++ b/src/cborencoder_float.c
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Break Copyright (C) 2019
+** Copyright (C) 2019 S.Phirsov
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to deal

--- a/src/cborencoder_float.c
+++ b/src/cborencoder_float.c
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2017 Intel Corporation
+** Break Copyright (C) 2019
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to deal
@@ -22,23 +22,21 @@
 **
 ****************************************************************************/
 
-#include "../../src/cborencoder.c"
-#include "../../src/cborencoder_float.c"
-#include "../../src/cborerrorstrings.c"
-#include "../../src/cborparser.c"
-#include "../../src/cborparser_dup_string.c"
-#include "../../src/cborparser_float.c"
-#include "../../src/cborvalidation.c"
+#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
+#ifndef __STDC_LIMIT_MACROS
+#  define __STDC_LIMIT_MACROS 1
+#endif
 
-#include <QtTest>
+#include "cbor.h"
 
-// This is a compilation-only test.
-// All it does is verify that the four source files above
-// compile as C++ without errors.
-class tst_Cpp : public QObject
+#include "cborinternal_p.h"
+
+#ifndef CBOR_NO_HALF_FLOAT_TYPE
+CborError cbor_encode_float_as_half_float(CborEncoder *encoder, float value)
 {
-    Q_OBJECT
-};
+    uint16_t v = (uint16_t)encode_half(value);
 
-QTEST_MAIN(tst_Cpp)
-#include "tst_cpp.moc"
+    return cbor_encode_floating_point(encoder, CborHalfFloatType, &v);
+}
+#endif

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -1414,17 +1414,32 @@ error:
  * floating point, this function takes a \c{void *} as a parameter for the
  * storage area, which must be at least 16 bits wide.
  *
- * \sa cbor_value_get_type(), cbor_value_is_valid(), cbor_value_is_half_float(), cbor_value_get_float()
+ * \sa cbor_value_get_type(), cbor_value_is_valid(), cbor_value_is_half_float(), cbor_value_get_half_float_as_float(), cbor_value_get_float()
  */
 CborError cbor_value_get_half_float(const CborValue *value, void *result)
 {
     uint16_t v;
-    cbor_assert(cbor_value_is_half_float(value));
 
-    /* size has been computed already */
-    v = get16(value->ptr + 1);
+    v = _cbor_value_get_half_float_helper(value);
     memcpy(result, &v, sizeof(v));
+
     return CborNoError;
+}
+
+/** \internal
+ *
+ * Retrieves the CBOR half-precision floating point value binary
+ * representation as 16-bit unsigned integer.
+ * The result can be used as-is, e.g. to copy bitwise into the
+ * system-dependent half-precision floating point type, or it can be
+ * converted to the C language standard floating point type
+ * (float or double).
+ */
+CBOR_PRIVATE_API uint16_t _cbor_value_get_half_float_helper(const CborValue *value)
+{
+    cbor_assert(cbor_value_is_half_float(value));
+    /* size has been computed already */
+    return get16(value->ptr + 1);
 }
 
 /** @} */

--- a/src/cborparser_float.c
+++ b/src/cborparser_float.c
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Break Copyright (C) 2019
+** Copyright (C) 2019 S.Phirsov
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to deal

--- a/src/cborparser_float.c
+++ b/src/cborparser_float.c
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2017 Intel Corporation
+** Break Copyright (C) 2019
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to deal
@@ -22,23 +22,33 @@
 **
 ****************************************************************************/
 
-#include "../../src/cborencoder.c"
-#include "../../src/cborencoder_float.c"
-#include "../../src/cborerrorstrings.c"
-#include "../../src/cborparser.c"
-#include "../../src/cborparser_dup_string.c"
-#include "../../src/cborparser_float.c"
-#include "../../src/cborvalidation.c"
+#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
+#ifndef __STDC_LIMIT_MACROS
+#  define __STDC_LIMIT_MACROS 1
+#endif
 
-#include <QtTest>
+#include "cbor.h"
 
-// This is a compilation-only test.
-// All it does is verify that the four source files above
-// compile as C++ without errors.
-class tst_Cpp : public QObject
+#include "cborinternal_p.h"
+
+#ifndef CBOR_NO_HALF_FLOAT_TYPE
+/**
+ * Retrieves the CBOR half-precision floating point (16-bit) value that \a
+ * value points to, converts it to the float and store it in \a result.
+ * If the iterator \a value does not point to a half-precision floating
+ * point value, the behavior is undefined, so checking with \ref
+ * cbor_value_get_type or with \ref cbor_value_is_half_float is recommended.
+ * \sa cbor_value_get_type(), cbor_value_is_valid(), cbor_value_is_half_float(), cbor_value_get_half_float(), cbor_value_get_float()
+ */
+CborError cbor_value_get_half_float_as_float(const CborValue *value, float *result)
 {
-    Q_OBJECT
-};
+    uint16_t v;
 
-QTEST_MAIN(tst_Cpp)
-#include "tst_cpp.moc"
+    v = _cbor_value_get_half_float_helper(value);
+
+    *result = (float)decode_half((unsigned short)v);
+
+    return CborNoError;
+}
+#endif


### PR DESCRIPTION
Motivation: half-precision floating point format is used to minimize storage and traffic mostly.
Application level manipulates with single and double precision usually. So, two routines added to public API to encode/decode given single precision value in the half precision format