### PR TITLE
Validation: fix out-of-bounds access when content ends in a string

### DIFF
--- a/src/cborpretty.c
+++ b/src/cborpretty.c
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2018 Intel Corporation
+** Copyright (C) 2019 Intel Corporation
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to deal
@@ -422,6 +422,8 @@ static CborError value_to_pretty(CborStreamFunction stream, void *out, CborValue
             }
 
             err = _cbor_value_get_string_chunk(it, &ptr, &n, it);
+            if (err)
+                return err;
             if (!ptr)
                 break;
 

--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2017 Intel Corporation
+** Copyright (C) 2019 Intel Corporation
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to deal
@@ -561,13 +561,17 @@ static CborError validate_value(CborValue *it, uint32_t flags, int recursionLeft
             return err;
 
         while (1) {
-            err = validate_number(it, type, flags);
+            CborValue next;
+            err = _cbor_value_get_string_chunk(it, &ptr, &n, &next);
             if (err)
                 return err;
+            if (ptr) {
+                err = validate_number(it, type, flags);
+                if (err)
+                    return err;
+            }
 
-            err = _cbor_value_get_string_chunk(it, &ptr, &n, it);
-            if (err)
-                return err;
+            *it = next;
             if (!ptr)
                 break;
 

--- a/tests/parser/tst_parser.cpp
+++ b/tests/parser/tst_parser.cpp
@@ -122,13 +122,19 @@ struct ParserWrapper
 
     ~ParserWrapper() { freeMemory(); }
 
-    CborError init(const QByteArray &ba)
+    CborError init(const QByteArray &ba, uint32_t flags = 0)
+    {
+        return init(ba.constData(), ba.size(), flags);
+    }
+    CborError init(const char *ptr, int n, uint32_t flags = 0)
     {
         freeMemory();
-        data = allocateMemory(ba.size());
-        memcpy(data, ba.data(), ba.size());
-        return cbor_parser_init(data, len, 0, &parser, &first);
+        data = allocateMemory(n);
+        memcpy(data, ptr, len);
+        return cbor_parser_init(data, len, flags, &parser, &first);
     }
+    uint8_t *begin() { return data; }
+    uint8_t *end()   { return data + len; }
 
     uint8_t *allocateMemory(size_t);
     void freeMemory();
@@ -244,47 +250,46 @@ bool compareFailed = true;
 void compareOne_real(const QByteArray &data, const QString &expected, int line, int n = -1)
 {
     compareFailed = true;
-    CborParser parser;
-    CborValue first;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), 0, &parser, &first);
+    ParserWrapper w;
+    CborError err = w.init(data);
     QVERIFY2(!err, QByteArray::number(line) + ": Got error \"" + cbor_error_string(err) + "\"");
 
-    if (cbor_value_get_type(&first) == CborArrayType) {
+    if (cbor_value_get_type(&w.first) == CborArrayType) {
         size_t len;
         if (n >= 0) {
-            QVERIFY(cbor_value_is_length_known(&first));
-            QCOMPARE(cbor_value_get_array_length(&first, &len), CborNoError);
+            QVERIFY(cbor_value_is_length_known(&w.first));
+            QCOMPARE(cbor_value_get_array_length(&w.first, &len), CborNoError);
             QCOMPARE(len, size_t(len));
         } else {
-            QVERIFY(!cbor_value_is_length_known(&first));
-            QCOMPARE(cbor_value_get_array_length(&first, &len), CborErrorUnknownLength);
+            QVERIFY(!cbor_value_is_length_known(&w.first));
+            QCOMPARE(cbor_value_get_array_length(&w.first, &len), CborErrorUnknownLength);
         }
-    } else if (cbor_value_get_type(&first) == CborMapType) {
+    } else if (cbor_value_get_type(&w.first) == CborMapType) {
         size_t len;
         if (n >= 0) {
-            QVERIFY(cbor_value_is_length_known(&first));
-            QCOMPARE(cbor_value_get_map_length(&first, &len), CborNoError);
+            QVERIFY(cbor_value_is_length_known(&w.first));
+            QCOMPARE(cbor_value_get_map_length(&w.first, &len), CborNoError);
             QCOMPARE(len, size_t(len));
         } else {
-            QVERIFY(!cbor_value_is_length_known(&first));
-            QCOMPARE(cbor_value_get_map_length(&first, &len), CborErrorUnknownLength);
+            QVERIFY(!cbor_value_is_length_known(&w.first));
+            QCOMPARE(cbor_value_get_map_length(&w.first, &len), CborErrorUnknownLength);
         }
-    } else if (cbor_value_is_text_string(&first) || cbor_value_is_byte_string(&first)) {
+    } else if (cbor_value_is_text_string(&w.first) || cbor_value_is_byte_string(&w.first)) {
         size_t len;
-        QCOMPARE(cbor_value_calculate_string_length(&first, &len), CborNoError);
-        if (cbor_value_is_length_known(&first)) {
+        QCOMPARE(cbor_value_calculate_string_length(&w.first, &len), CborNoError);
+        if (cbor_value_is_length_known(&w.first)) {
             size_t len2;
-            QCOMPARE(cbor_value_get_string_length(&first, &len2), CborNoError);
+            QCOMPARE(cbor_value_get_string_length(&w.first, &len2), CborNoError);
             QCOMPARE(len2, len);
         } else {
-            QCOMPARE(cbor_value_get_string_length(&first, &len), CborErrorUnknownLength);
+            QCOMPARE(cbor_value_get_string_length(&w.first, &len), CborErrorUnknownLength);
         }
     }
 
-    CborError err2 = cbor_value_validate_basic(&first);
+    CborError err2 = cbor_value_validate_basic(&w.first);
 
     QString decoded;
-    err = parseOne(&first, &decoded);
+    err = parseOne(&w.first, &decoded);
     QVERIFY2(!err, QByteArray::number(line) + ": Got error \"" + cbor_error_string(err) +
                    "\"; decoded stream:\n" + decoded.toLatin1());
     QCOMPARE(decoded, expected);
@@ -293,7 +298,7 @@ void compareOne_real(const QByteArray &data, const QString &expected, int line, 
     QCOMPARE(err2, err);
 
     // check that we consumed everything
-    QCOMPARE((void*)cbor_value_get_next_byte(&first), (void*)data.constEnd());
+    QCOMPARE((void*)cbor_value_get_next_byte(&w.first), (void*)w.end());
 
     compareFailed = false;
 }
@@ -459,36 +464,35 @@ void tst_Parser::integers()
     QFETCH(qint64, expectedValue);
     QFETCH(bool, inInt64Range);
 
-    CborParser parser;
-    CborValue first;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), 0, &parser, &first);
+    ParserWrapper w;
+    CborError err = w.init(data);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
-    QVERIFY(cbor_value_is_integer(&first));
+    QVERIFY(cbor_value_is_integer(&w.first));
 
     uint64_t raw;
-    cbor_value_get_raw_integer(&first, &raw);
+    cbor_value_get_raw_integer(&w.first, &raw);
     QCOMPARE(quint64(raw), expectedRaw);
 
     if (isNegative) {
-        QVERIFY(cbor_value_is_negative_integer(&first));
-        QVERIFY(!cbor_value_is_unsigned_integer(&first));
+        QVERIFY(cbor_value_is_negative_integer(&w.first));
+        QVERIFY(!cbor_value_is_unsigned_integer(&w.first));
     } else {
-        QVERIFY(!cbor_value_is_negative_integer(&first));
-        QVERIFY(cbor_value_is_unsigned_integer(&first));
+        QVERIFY(!cbor_value_is_negative_integer(&w.first));
+        QVERIFY(cbor_value_is_unsigned_integer(&w.first));
     }
 
     int64_t value;
     if (inInt64Range) {
-        cbor_value_get_int64(&first, &value);
+        cbor_value_get_int64(&w.first, &value);
         QCOMPARE(qint64(value), expectedValue);
     }
 
-    err = cbor_value_get_int64_checked(&first, &value);
+    err = cbor_value_get_int64_checked(&w.first, &value);
     QCOMPARE(err, inInt64Range ? CborNoError : CborErrorDataTooLarge);
 
     int ivalue;
     bool inIntRange = inInt64Range && (expectedValue == int(expectedValue));
-    err = cbor_value_get_int_checked(&first, &ivalue);
+    err = cbor_value_get_int_checked(&w.first, &ivalue);
     QCOMPARE(err, inIntRange ? CborNoError : CborErrorDataTooLarge);
 }
 
@@ -966,14 +970,13 @@ void tst_Parser::chunkedString_data()
 static void chunkedStringTest(const QByteArray &data, const QString &concatenated,
                               QStringList &chunks, CborType ourType)
 {
-    CborParser parser;
-    CborValue first;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), 0, &parser, &first);
+    ParserWrapper w;
+    CborError err = w.init(data);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
 
     CborValue value;
-    QVERIFY(cbor_value_is_array(&first));
-    err = cbor_value_enter_container(&first, &value);
+    QVERIFY(cbor_value_is_array(&w.first));
+    err = cbor_value_enter_container(&w.first, &value);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
     QVERIFY(cbor_value_is_byte_string(&value) || cbor_value_is_text_string(&value));
 
@@ -1020,9 +1023,9 @@ static void chunkedStringTest(const QByteArray &data, const QString &concatenate
     // confirm EOF
     QVERIFY(cbor_value_at_end(&value));
 
-    err = cbor_value_leave_container(&first, &value);
+    err = cbor_value_leave_container(&w.first, &value);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
-    QCOMPARE((void*)cbor_value_get_next_byte(&first), (void*)data.constEnd());
+    QCOMPARE((void*)cbor_value_get_next_byte(&w.first), (void*)w.end());
 }
 
 void tst_Parser::chunkedString()
@@ -1112,18 +1115,17 @@ void tst_Parser::stringLength()
     QFETCH(QByteArray, data);
     QFETCH(int, expected);
 
-    CborParser parser;
-    CborValue value;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), 0, &parser, &value);
+    ParserWrapper w;
+    CborError err = w.init(data);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
 
     size_t result;
-    err = cbor_value_calculate_string_length(&value, &result);
+    err = cbor_value_calculate_string_length(&w.first, &result);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
     QCOMPARE(result, size_t(expected));
 
-    if (cbor_value_is_length_known(&value)) {
-        QCOMPARE(cbor_value_get_string_length(&value, &result), CborNoError);
+    if (cbor_value_is_length_known(&w.first)) {
+        QCOMPARE(cbor_value_get_string_length(&w.first, &result), CborNoError);
         QCOMPARE(result, size_t(expected));
     }
 
@@ -1207,25 +1209,24 @@ void compareOneString(const QByteArray &data, const QString &string, bool expect
 {
     compareFailed = true;
 
-    CborParser parser;
-    CborValue value;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), 0, &parser, &value);
+    ParserWrapper w;
+    CborError err = w.init(data);
     QVERIFY2(!err, QByteArray::number(line) + ": Got error \"" + cbor_error_string(err) + "\"");
 
     bool result;
     QByteArray bastring = string.toUtf8();
-    err = cbor_value_text_string_equals(&value, bastring.constData(), &result);
+    err = cbor_value_text_string_equals(&w.first, bastring.constData(), &result);
     QVERIFY2(!err, QByteArray::number(line) + ": Got error \"" + cbor_error_string(err) + "\"");
     QCOMPARE(result, expected);
 
     if (expected) {
         size_t len;
-        cbor_value_skip_tag(&value);
-        if (cbor_value_is_length_known(&value)) {
-            QCOMPARE(cbor_value_get_string_length(&value, &len), CborNoError);
+        cbor_value_skip_tag(&w.first);
+        if (cbor_value_is_length_known(&w.first)) {
+            QCOMPARE(cbor_value_get_string_length(&w.first, &len), CborNoError);
             QCOMPARE(int(len), bastring.size());
         }
-        QCOMPARE(cbor_value_calculate_string_length(&value, &len), CborNoError);
+        QCOMPARE(cbor_value_calculate_string_length(&w.first, &len), CborNoError);
         QCOMPARE(int(len), bastring.size());
     }
 
@@ -1314,13 +1315,12 @@ void tst_Parser::mapFind()
     QFETCH(QByteArray, data);
     QFETCH(bool, expected);
 
-    CborParser parser;
-    CborValue value;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), 0, &parser, &value);
+    ParserWrapper w;
+    CborError err = w.init(data);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
 
     CborValue element;
-    err = cbor_value_map_find_value(&value, "needle", &element);
+    err = cbor_value_map_find_value(&w.first, "needle", &element);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
 
     if (expected) {
@@ -1391,13 +1391,12 @@ void tst_Parser::checkedIntegers()
     QFETCH(QVariant, result);
     int64_t expected = result.toLongLong();
 
-    CborParser parser;
-    CborValue value;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), 0, &parser, &value);
+    ParserWrapper w;
+    CborError err = w.init(data);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
 
     int64_t v;
-    err = cbor_value_get_int64_checked(&value, &v);
+    err = cbor_value_get_int64_checked(&w.first, &v);
     if (result.isNull()) {
         QCOMPARE(err, CborErrorDataTooLarge);
     } else {
@@ -1405,7 +1404,7 @@ void tst_Parser::checkedIntegers()
     }
 
     int v2;
-    err = cbor_value_get_int_checked(&value, &v2);
+    err = cbor_value_get_int_checked(&w.first, &v2);
     if (result.isNull() || expected < std::numeric_limits<int>::min() || expected > std::numeric_limits<int>::max()) {
         QCOMPARE(err, CborErrorDataTooLarge);
     } else {
@@ -1664,14 +1663,13 @@ void tst_Parser::validation()
     QFETCH(CborError, expectedError);
 
     QString decoded;
-    CborParser parser;
-    CborValue first;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), flags, &parser, &first);
+    ParserWrapper w;
+    CborError err = w.init(data, uint32_t(flags));
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
 
-    CborError err2 = cbor_value_validate_basic(&first);
-    CborError err3 = cbor_value_validate(&first, CborValidateBasic);
-    err = parseOne(&first, &decoded);
+    CborError err2 = cbor_value_validate_basic(&w.first);
+    CborError err3 = cbor_value_validate(&w.first, CborValidateBasic);
+    err = parseOne(&w.first, &decoded);
     QCOMPARE(err, expectedError);
     if (!QByteArray(QTest::currentDataTag()).contains("utf8")) {
         QCOMPARE(err2, expectedError);
@@ -2070,12 +2068,11 @@ void tst_Parser::resumeParsing()
     QFETCH(QString, expected);
 
     for (int len = 0; len < data.length() - 1; ++len) {
-        CborParser parser;
-        CborValue first;
-        CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), len, 0, &parser, &first);
+        ParserWrapper w;
+        CborError err = w.init(data.constData(), len);
         if (!err) {
             QString decoded;
-            err = parseOne(&first, &decoded);
+            err = parseOne(&w.first, &decoded);
         }
         if (err != CborErrorUnexpectedEOF)
             qDebug() << "Length is" << len;
@@ -2104,14 +2101,13 @@ void tst_Parser::endPointer()
     QFETCH(int, offset);
 
     QString decoded;
-    CborParser parser;
-    CborValue first;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), 0, &parser, &first);
+    ParserWrapper w;
+    CborError err = w.init(data);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
 
-    err = parseOne(&first, &decoded);
+    err = parseOne(&w.first, &decoded);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
-    QCOMPARE(int(first.ptr - reinterpret_cast<const quint8 *>(data.constBegin())), offset);
+    QCOMPARE(int(cbor_value_get_next_byte(&w.first) - w.begin()), offset);
 }
 
 void tst_Parser::recursionLimit_data()
@@ -2159,24 +2155,23 @@ void tst_Parser::recursionLimit()
 {
     QFETCH(QByteArray, data);
 
-    CborParser parser;
-    CborValue first;
-    CborError err = cbor_parser_init(reinterpret_cast<const quint8 *>(data.constData()), data.length(), 0, &parser, &first);
+    ParserWrapper w;
+    CborError err = w.init(data);
     QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
 
     // check that it is valid:
-    CborValue it = first;
+    CborValue it = w.first;
     {
         QString dummy;
         err = parseOne(&it, &dummy);
         QVERIFY2(!err, QByteArray("Got error \"") + cbor_error_string(err) + "\"");
     }
 
-    it = first;
+    it = w.first;
     err = cbor_value_advance(&it);
     QCOMPARE(err, CborErrorNestingTooDeep);
 
-    it = first;
+    it = w.first;
     if (cbor_value_is_map(&it)) {
         CborValue dummy;
         err = cbor_value_map_find_value(&it, "foo", &dummy);


### PR DESCRIPTION
We can only validate_number() if we know that we have a number to
validate in the first place. If we've reached the end of our string, the
content that follows is not necessarily a number (it could be a Break
byte). More importantly, we could reach the end of the buffer.

This issue was masked by the way we provided data to the parser. It
always came from read-only memory becausee of QByteArray::fromRawData(),
so valgrind never caught any issues. Using QByteArray directly wouldn't
have helped because it always inserts a terminating null byte, which
always validates as a correct number (unsigned 0) and fails to trigger
valgrind.

So we need to use malloc() directly to make Valgrind complain. And there
was already a test that did:

==26543== Invalid read of size 1
==26543==    at 0x483EA10: memmove (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==26543==    by 0x43CEEA: read_bytes_unchecked (cborinternal_p.h:239)
==26543==    by 0x43CFEC: extract_number_checked (cborinternal_p.h:286)
==26543==    by 0x43D3E9: validate_number (cborvalidation.c:304)
==26543==    by 0x43DC7B: validate_value (cborvalidation.c:551)
==26543==    by 0x43DE8C: cbor_value_validate (cborvalidation.c:645)
==26543==    by 0x4328D2: tst_Parser::strictValidation() (tst_parser.cpp:1637)
==26543==    by 0x434632: tst_Parser::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (tst_parser.moc:291)
==26543==    by 0x4C0B36D: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (qmetaobject.cpp:2310)
==26543==    by 0x48673E9: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (qmetaobject.h:122)
==26543==    by 0x4860256: QTest::TestMethods::invokeTestOnData(int) const (qtestcase.cpp:922)
==26543==    by 0x4860D4B: QTest::TestMethods::invokeTest(int, char const*, QTest::WatchDog*) const (qtestcase.cpp:1121)
==26543==  Address 0x61c4db1 is 0 bytes after a block of size 1 alloc'd
==26543==    at 0x483777F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==26543==    by 0x403891: ParserWrapper::allocateMemory(unsigned long) (tst_parser.cpp:181)
==26543==    by 0x436898: ParserWrapper::init(QByteArray const&) (tst_parser.cpp:126)
==26543==    by 0x432712: tst_Parser::strictValidation() (tst_parser.cpp:1634)
==26543==    by 0x434632: tst_Parser::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (tst_parser.moc:291)
==26543==    by 0x4C0B36D: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (qmetaobject.cpp:2310)
==26543==    by 0x48673E9: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (qmetaobject.h:122)
==26543==    by 0x4860256: QTest::TestMethods::invokeTestOnData(int) const (qtestcase.cpp:922)
==26543==    by 0x4860D4B: QTest::TestMethods::invokeTest(int, char const*, QTest::WatchDog*) const (qtestcase.cpp:1121)
==26543==    by 0x4862083: QTest::TestMethods::invokeTests(QObject*) const (qtestcase.cpp:1465)
==26543==    by 0x4862C14: QTest::qRun() (qtestcase.cpp:1903)
==26543==    by 0x48626C3: QTest::qExec(QObject*, int, char**) (qtestcase.cpp:1792)
==26543==
PASS   : tst_Parser::strictValidation(bytearray-0)

This commit goes further and makes it so an out-of-bounds access will
cause a pagefault.

Fixes #156.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>