### PR TITLE
Tests: Catch an earlier QCOMPARE failure in compare()

### DIFF
--- a/tests/encoder/tst_encoder.cpp
+++ b/tests/encoder/tst_encoder.cpp
@@ -303,6 +303,8 @@ void compare(Input input, FnUnderTest fn_under_test, const QByteArray &output)
     CborError error;
 
     encodeOne(input, fn_under_test, buffer, error);
+    if (QTest::currentTestFailed())
+        return;
 
     QCOMPARE(error, CborNoError);
     QCOMPARE(buffer, output);


### PR DESCRIPTION
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>