### PR TITLE
Ability to reset an encoder

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -208,6 +208,7 @@ struct CborEncoder
         uint8_t *ptr;
         ptrdiff_t bytes_needed;
     } data;
+    uint8_t *start;
     const uint8_t *end;
     size_t remaining;
     int flags;
@@ -227,6 +228,7 @@ CBOR_INLINE_API CborError cbor_encode_text_stringz(CborEncoder *encoder, const c
 { return cbor_encode_text_string(encoder, string, strlen(string)); }
 CBOR_API CborError cbor_encode_byte_string(CborEncoder *encoder, const uint8_t *string, size_t length);
 CBOR_API CborError cbor_encode_floating_point(CborEncoder *encoder, CborType fpType, const void *value);
+
 
 CBOR_INLINE_API CborError cbor_encode_boolean(CborEncoder *encoder, bool value)
 { return cbor_encode_simple_value(encoder, (int)value - 1 + (CborBooleanType & 0x1f)); }
@@ -261,6 +263,9 @@ CBOR_INLINE_API size_t cbor_encoder_get_extra_bytes_needed(const CborEncoder *en
 {
     return encoder->end ? 0 : (size_t)encoder->data.bytes_needed;
 }
+
+CBOR_INLINE_API void cbor_encoder_reset(CborEncoder *encoder)
+{ encoder->data.ptr = encoder->start; }
 
 /* Parser API */
 

--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -203,6 +203,7 @@
 void cbor_encoder_init(CborEncoder *encoder, uint8_t *buffer, size_t size, int flags)
 {
     encoder->data.ptr = buffer;
+    encoder->start = buffer;
     encoder->end = buffer + size;
     encoder->remaining = 2;
     encoder->flags = flags;
@@ -433,7 +434,7 @@ static CborError encode_string(CborEncoder *encoder, size_t length, uint8_t shif
  */
 
 /**
- * Appends the text string \a string of length \a length to the CBOR stream
+ * Appends the byte string \a string of length \a length to the CBOR stream
  * provided by \a encoder. CBOR requires that \a string be valid UTF-8, but
  * TinyCBOR makes no verification of correctness.
  *
@@ -445,7 +446,7 @@ CborError cbor_encode_byte_string(CborEncoder *encoder, const uint8_t *string, s
 }
 
 /**
- * Appends the byte string \a string of length \a length to the CBOR stream
+ * Appends the text string \a string of length \a length to the CBOR stream
  * provided by \a encoder. CBOR byte strings are arbitrary raw data.
  *
  * \sa cbor_encode_text_stringz, cbor_encode_text_string
@@ -640,6 +641,15 @@ CborError cbor_encoder_close_container(CborEncoder *encoder, const CborEncoder *
  * See \ref CborEncoding for an example of using this function.
  *
  * \sa cbor_encoder_init(), cbor_encoder_get_buffer_size(), CborEncoding
+ */
+
+/**
+ * \fn void cbor_encoder_reset(CborEncoder *encoder)
+ *
+ * Reset the encoder. The encoder will now start writing from the beginning of
+ * its allocated buffer space.
+ *
+ * \sa cbor_encoder_init
  */
 
 /** @} */


### PR DESCRIPTION
Added a method that allows for resetting an encoder (Start writing from the beginning of the buffer). This is very useful when you quickly want to discard everything that has currently been encoded by that encoder. 

Also, a mixup in the documentation was adjusted (cborencoder.c).