### PR TITLE
Added the method cbor_encode_raw to the API

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2017 Intel Corporation
+** Copyright (C) 2019 Intel Corporation
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to deal
@@ -270,7 +270,8 @@ enum CborParserIteratorFlags
     CborIteratorFlag_NegativeInteger        = 0x02,
     CborIteratorFlag_IteratingStringChunks  = 0x02,
     CborIteratorFlag_UnknownLength          = 0x04,
-    CborIteratorFlag_ContainerIsMap         = 0x20
+    CborIteratorFlag_ContainerIsMap         = 0x20,
+    CborIteratorFlag_NextIsMapKey           = 0x40
 };
 
 struct CborParser

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -227,6 +227,7 @@ CBOR_INLINE_API CborError cbor_encode_text_stringz(CborEncoder *encoder, const c
 { return cbor_encode_text_string(encoder, string, strlen(string)); }
 CBOR_API CborError cbor_encode_byte_string(CborEncoder *encoder, const uint8_t *string, size_t length);
 CBOR_API CborError cbor_encode_floating_point(CborEncoder *encoder, CborType fpType, const void *value);
+CBOR_API CborError cbor_encode_raw(CborEncoder *encoder, const uint8_t *raw, size_t length);
 
 CBOR_INLINE_API CborError cbor_encode_boolean(CborEncoder *encoder, bool value)
 { return cbor_encode_simple_value(encoder, (int)value - 1 + (CborBooleanType & 0x1f)); }

--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -445,6 +445,20 @@ CborError cbor_encode_byte_string(CborEncoder *encoder, const uint8_t *string, s
 }
 
 /**
+ * Puts the data of length \a length in \a raw into to the encoding buffer of \a 
+ * encoder. This function can be used if you have stored CBOR encoded data and
+ * want to push it to your current encoding buffer. Be aware, you are 
+ * responsible for the data in \a raw is valid and that the validity of the
+ * resulting stream after this operation remains valid.
+ *
+ * \sa CborError cbor_encode_byte_string
+ */
+CborError cbor_encode_raw(CborEncoder *encoder, const uint8_t *raw, size_t length)
+{
+    return append_to_buffer(encoder, raw, length);
+}
+
+/**
  * Appends the byte string \a string of length \a length to the CBOR stream
  * provided by \a encoder. CBOR byte strings are arbitrary raw data.
  *

--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -65,7 +65,7 @@
  * \code
  *      uint8_t buf[16];
  *      CborEncoder encoder;
- *      cbor_encoder_init(&encoder, &buf, sizeof(buf), 0);
+ *      cbor_encoder_init(&encoder, buf, sizeof(buf), 0);
  *      cbor_encode_int(&encoder, some_value);
  * \endcode
  *

--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -117,16 +117,16 @@
  *      CborEncoder encoder, mapEncoder;
  *      cbor_encoder_init(&encoder, buf, sizeof(buf), 0);
  *      err = cbor_encoder_create_map(&encoder, &mapEncoder, 1);
- *      if (!err)
+ *      if (err)
  *          return err;
  *      err = cbor_encode_text_stringz(&mapEncoder, "foo");
- *      if (!err)
+ *      if (err)
  *          return err;
  *      err = cbor_encode_boolean(&mapEncoder, some_value);
- *      if (!err)
+ *      if (err)
  *          return err;
  *      err = cbor_encoder_close_container_checked(&encoder, &mapEncoder);
- *      if (!err)
+ *      if (err)
  *          return err;
  *
  *      size_t len = cbor_encoder_get_buffer_size(&encoder, buf);
@@ -157,7 +157,7 @@
  *
  *         cbor_encoder_init(&encoder, buf, size, 0);
  *         err = cbor_encoder_create_array(&encoder, &arrayEncoder, n);
- *         cbor_assert(err);         // can't fail, the buffer is always big enough
+ *         cbor_assert(!err);         // can't fail, the buffer is always big enough
  *
  *         for (i = 0; i < n; ++i) {
  *             err = cbor_encode_text_stringz(&arrayEncoder, strings[i]);
@@ -166,7 +166,7 @@
  *         }
  *
  *         err = cbor_encoder_close_container_checked(&encoder, &arrayEncoder);
- *         cbor_assert(err);         // shouldn't fail!
+ *         cbor_assert(!err);         // shouldn't fail!
  *
  *         more_bytes = cbor_encoder_get_extra_bytes_needed(encoder);
  *         if (more_size) {


### PR DESCRIPTION
This method allows for writing raw data directly to the encoding buffer. Particularly useful if you have something stored as CBOR encoded data and want to push it to your encoding stream/buffer.