### PR TITLE
Allow to override install prefix in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Variables:
-prefix = /usr/local
+prefix ?= /usr/local
 exec_prefix = $(prefix)
 bindir = $(exec_prefix)/bin
 libdir = $(exec_prefix)/lib


### PR DESCRIPTION
This way, the makefile can install in the system directories (eg: distribution packages)