### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -372,7 +372,7 @@ static CborError tagged_value_to_json(FILE *out, CborValue *it, int flags, Conve
     if (type == CborByteStringType && (flags & CborConvertByteStringsToBase64Url) == 0 &&
             (tag == CborNegativeBignumTag || tag == CborExpectedBase16Tag || tag == CborExpectedBase64Tag)) {
         char *str;
-        char *pre = "";
+        const char *pre = "";
 
         if (tag == CborNegativeBignumTag) {
             pre = "~";

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -44,7 +44,7 @@
 #  include <stdbool.h>
 #endif
 
-#if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L || __cpp_static_assert >= 200410
+#if __STDC_VERSION__ >= 201112L || (defined(__cplusplus) && __cplusplus >= 201103L) || (defined(__cpp_static_assert) && __cpp_static_assert >= 200410)
 #  define cbor_static_assert(x)         static_assert(x, #x)
 #elif !defined(__cplusplus) && defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 406) && (__STDC_VERSION__ > 199901L)
 #  define cbor_static_assert(x)         _Static_assert(x, #x)


### PR DESCRIPTION
cbortojson.c
Fix warning: initialization discards 'const' qualifier from pointer target type

compilersupport_p.h 
Fix warning: __cplusplus / __cpp_static_assert is not defined …
