### PR TITLE
Warning removals

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -1093,7 +1093,8 @@ static uintptr_t iterate_memcmp(char *s1, const uint8_t *s2, size_t len)
 
 static uintptr_t iterate_memcpy(char *dest, const uint8_t *src, size_t len)
 {
-    return (uintptr_t)memcpy(dest, src, len);
+    memcpy(dest, src, len);
+    return (uintptr_t)dest;
 }
 
 static CborError iterate_string_chunks(const CborValue *value, char *buffer, size_t *buflen,

--- a/src/cborpretty_stdio.c
+++ b/src/cborpretty_stdio.c
@@ -26,6 +26,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+static CborError cbor_fprintf(void *out, const char *fmt, ...) __attribute__ ((format (gnu_printf, 2, 3)));
 static CborError cbor_fprintf(void *out, const char *fmt, ...)
 {
     int n;

--- a/src/cborpretty_stdio.c
+++ b/src/cborpretty_stdio.c
@@ -26,7 +26,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#ifdef __GNUC__
 static CborError cbor_fprintf(void *out, const char *fmt, ...) __attribute__ ((format (gnu_printf, 2, 3)));
+#endif
 static CborError cbor_fprintf(void *out, const char *fmt, ...)
 {
     int n;

--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -146,8 +146,6 @@
  * the keys for the metadata clash with existing keys in the JSON map.
  */
 
-extern FILE *open_memstream(char **bufptr, size_t *sizeptr);
-
 enum ConversionStatusFlags {
     TypeWasNotNative            = 0x100,    /* anything but strings, boolean, null, arrays and maps */
     TypeWasTagged               = 0x200,


### PR DESCRIPTION
- warning removal: redundant redecleration of open_memstream (in stdio)
- warning removal: function might be possible candidate for gnu_printf
- warning removal: cast from void* to uintptr_t (can't be guaranteed without loss of information in c99

from: Mathieu / mathieu[at]themooltipass[dot]com