### PR TITLE
Fix -Werror,-Wself-assign on big-endian systems

### DIFF
--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -210,8 +210,8 @@ void cbor_encoder_init(CborEncoder *encoder, uint8_t *buffer, size_t size, int f
 
 static inline void put16(void *where, uint16_t v)
 {
-    v = cbor_htons(v);
-    memcpy(where, &v, sizeof(v));
+    uint16_t v_be = cbor_htons(v);
+    memcpy(where, &v_be, sizeof(v_be));
 }
 
 /* Note: Since this is currently only used in situations where OOM is the only
@@ -227,14 +227,14 @@ static inline bool isOomError(CborError err)
 
 static inline void put32(void *where, uint32_t v)
 {
-    v = cbor_htonl(v);
-    memcpy(where, &v, sizeof(v));
+    uint32_t v_be = cbor_htonl(v);
+    memcpy(where, &v_be, sizeof(v_be));
 }
 
 static inline void put64(void *where, uint64_t v)
 {
-    v = cbor_htonll(v);
-    memcpy(where, &v, sizeof(v));
+    uint64_t v_be = cbor_htonll(v);
+    memcpy(where, &v_be, sizeof(v_be));
 }
 
 static inline bool would_overflow(CborEncoder *encoder, size_t len)


### PR DESCRIPTION
I was getting the following error when compiling cborencoder.c as part of
QtBase for FreeBSD MIPS64:
error: explicitly assigning value of variable of type 'uint64_t' (aka 'unsigned long') to itself [-Werror,-Wself-assign]
    v = cbor_htonll(v);