### PR TITLE
it is unclear what the return value of iterate_memcpy should be.

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -1093,7 +1093,7 @@ static uintptr_t iterate_memcmp(char *s1, const uint8_t *s2, size_t len)
 
 static uintptr_t iterate_memcpy(char *dest, const uint8_t *src, size_t len)
 {
-    return (uintptr_t)memcpy(dest, src, len);
+    return (uintptr_t)(char *)memcpy(dest, src, len);
 }
 
 static CborError iterate_string_chunks(const CborValue *value, char *buffer, size_t *buflen,


### PR DESCRIPTION
Probably just true, but without this additional cast, I get a warning.
