### PR TITLE
Makefile: Use file name instead of file descriptor for .config target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ silentcheck: | $(BINLIBRARY)
 	TESTARGS=-silent $(MAKE) -f $(MAKEFILE) -s check
 configure: .config
 .config: Makefile.configure
-	$(MAKE) -f $(SRCDIR)Makefile.configure OUT='>&9' configure 9> $@
+	$(MAKE) -f $(SRCDIR)Makefile.configure OUT='$@' configure
 
 lib/libtinycbor-freestanding.a: $(TINYCBOR_FREESTANDING_SOURCES:.c=.o)
 	@$(MKDIR) -p lib

--- a/Makefile.configure
+++ b/Makefile.configure
@@ -27,9 +27,9 @@ sink:
 configure: $(foreach it,$(ALLTESTS),check-$(it))
 
 check-%:
-	@echo $(subst check-,,$@)-tested := 1 $(OUT)
+	@echo $(subst check-,,$@)-tested := 1 >>$(OUT)
 	$(if $(V),,@)if printf "$($(subst check-,PROGRAM-,$@))" | \
 	    $(CC) -xc $($(subst check-,CCFLAGS-,$@)) -o /dev/null - $(if $(V),,>/dev/null 2>&1); \
 	then \
-	    echo $(subst check-,,$@)-pass := 1 $(OUT); \
+	    echo $(subst check-,,$@)-pass := 1 >>$(OUT); \
 	fi


### PR DESCRIPTION
The project makefile uses fd 9 to redirect output, when generating the contents of the `.config` file. Previously, it used fd 10, but was changed due to compatibility concerns (https://github.com/intel/tinycbor/commit/c88913e53c7aeda47cdaa8947949af29f48697ff).

The build fails in environments where this file descriptor can't be used. I've encountered this error trying to build `tinycbor` as part of a dependency, from a Cargo crate build script which invokes `make` ([see logs](https://github.com/AlfioEmanueleFresta/xdg-credentials-portal/runs/3776889537#step:5:283)):

```
make[2]: *** read jobs pipe: Bad file descriptor.  Stop.
make[2]: *** Waiting for unfinished jobs....
/bin/sh: 1: 9: Bad file descriptor
```

Proposing a fix, changing the `OUT` variable to take a path to append to, instead of a redirection.

I've tested the change by running `make`, and verifying the contents of `.config` are the same as before my change.