### PR TITLE
Makefile: add -Werror=discarded-qualifiers to the C flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,7 @@ cflags += -std=gnu99 $(CFLAGS)
 
 ifneq ($(DISABLE_WERROR),1)
 cflags += \
+	-Werror=discarded-qualifiers \
 	-Werror=incompatible-pointer-types \
 	-Werror=implicit-function-declaration \
 	-Werror=int-conversion


### PR DESCRIPTION
Because C allows this:
```c
  void f(int *x);
  void g(const int *x)
  { f(x); }
```
