### PR TITLE
If the buffer pointer is a null pointer then don't apply an offset to it

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -1211,7 +1211,7 @@ static CborError iterate_string_chunks(const CborValue *value, char *buffer, siz
             return CborErrorDataTooLarge;
 
         if (*result && *buflen >= newTotal)
-            *result = !!func(buffer + total, (const uint8_t *)ptr, chunkLen);
+            *result = !!func(buffer == NULL ? buffer : buffer + total, (const uint8_t *)ptr, chunkLen);
         else
             *result = false;
 
@@ -1221,7 +1221,7 @@ static CborError iterate_string_chunks(const CborValue *value, char *buffer, siz
     /* is there enough room for the ending NUL byte? */
     if (*result && *buflen > total) {
         uint8_t nul[] = { 0 };
-        *result = !!func(buffer + total, nul, 1);
+        *result = !!func(buffer == NULL ? buffer : buffer + total, nul, 1);
     }
     *buflen = total;
     return _cbor_value_finish_string_iteration(next);


### PR DESCRIPTION
This is undefined behaviour as caught by Xcode 13.2.1:

```
/Users/ham/TinyCborObjc/tinycbor/src/cborparser.c:1214:37: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/ham/TinyCborObjc/tinycbor/src/cborparser.c:1214:37 in 

```