### PR TITLE
simplereader: Fix compilation

### DIFF
--- a/examples/simplereader.c
+++ b/examples/simplereader.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 
     if (err) {
         fprintf(stderr, "CBOR parsing failure at offset %ld: %s\n",
-                it.ptr - buf, cbor_error_string(err));
+                it.source.ptr - buf, cbor_error_string(err));
         return 1;
     }
     return 0;


### PR DESCRIPTION
Compilation of "`simplereader.c`" failed with an error message, on ARM7 embedded linux and GCC 9.3.0:

```
  arm-ngrave-linux-gnueabi-gcc -mthumb -mfpu=neon-vfpv4 -mfloat-abi=hard -mcpu=cortex-a7 --sysroot=[...] -c -pipe  -O2 -pipe -g -feliminate-unused-debug-types -ffunction-sections -fdata-sections -Wall -Wextra -fPIC -DNDEBUG -I. -I../src -I/[...]/mkspecs/linux-oe-g++ -o simplereader.o simplereader.c
  simplereader.c: In function 'main':
  simplereader.c:181:19: error: 'CborValue' {aka 'struct CborValue'} has no member named 'ptr'
    181 |                 it.ptr - buf, cbor_error_string(err));
        |                   ^
  Makefile:653: recipe for target 'simplereader.o' failed
  make: *** [simplereader.o] Error 1
```

Fixing the error is pretty simple, because the "`struct CborValue`" is defined in "`src/cbor.h`" as:

 ```
 struct CborValue
  {
      const CborParser *parser;
      union {
          const uint8_t *ptr;
          void *token;
      } source;
      [...]
  };
```

So we need to specify the "`source`" member of the "`struct CborValue`", between "`it`" and "`ptr`":

`  "it.ptr" -> "it.source.ptr"`

This fixes the compilation error.

Signed-off-by: Olivier L'Heureux <olivier.lheureux@mind.be>
Signed-off-by: Xavier Hendrickx <xavier.hendrickx@ngrave.io>
Reviewed-by: Evgeny Beysembaev <evgeny.beysembaev@ngrave.io>