### PR TITLE
cborpretty: fix assertion failure if recursion limit was hit

### DIFF
--- a/src/cborpretty.c
+++ b/src/cborpretty.c
@@ -314,7 +314,10 @@ static CborError container_to_pretty(CborStreamFunction stream, void *out, CborV
 
     if (!recursionsLeft) {
         printRecursionLimit(stream, out);
-        return err;     /* do allow the dumping to continue */
+        while (!cbor_value_at_end(it) && !err) {
+            err = cbor_value_advance(it);
+        }
+        return err;     /* do allow the dumping to continue (if the advance was OK) */
     }
 
     while (!cbor_value_at_end(it) && !err) {


### PR DESCRIPTION
Using `cbordump` on the enclosed input fails with an assertion error :
```
cbordump: src/cborparser.c:633: cbor_value_leave_container: Assertion `recursed->type == CborInvalidType' failed.
```
The problem is the following : there is an implicit assumption when quitting `container_to_pretty` that the iterator is advanced to its end. This assumption is broken whenever we reach the recursion limit.

The failing input was found by @niooss-ledger.
[max-recurse-limit-fail-input.txt](https://github.com/intel/tinycbor/files/10725330/max-recurse-limit-fail-input.txt)
