### PR TITLE
Use _Float16 for half conversions if available

### DIFF
--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -31,6 +31,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 
 #include "cbor.h"
 #include "cborinternal_p.h"

--- a/src/cborencoder_close_container_checked.c
+++ b/src/cborencoder_close_container_checked.c
@@ -27,6 +27,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 
 #include "cbor.h"
 

--- a/src/cborencoder_float.c
+++ b/src/cborencoder_float.c
@@ -27,6 +27,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 
 #include "cbor.h"
 

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -31,6 +31,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 
 #include "cbor.h"
 #include "cborinternal_p.h"

--- a/src/cborparser_dup_string.c
+++ b/src/cborparser_dup_string.c
@@ -31,6 +31,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 
 #include "cbor.h"
 #include "compilersupport_p.h"

--- a/src/cborparser_float.c
+++ b/src/cborparser_float.c
@@ -27,6 +27,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 
 #include "cbor.h"
 

--- a/src/cborpretty.c
+++ b/src/cborpretty.c
@@ -27,6 +27,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 
 #include "cbor.h"
 #include "cborinternal_p.h"

--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -28,6 +28,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 
 #include "cbor.h"
 #include "cborjson.h"

--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -27,6 +27,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #  define __STDC_LIMIT_MACROS 1
 #endif
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 
 #include "cbor.h"
 #include "cborinternal_p.h"

--- a/tools/json2cbor/json2cbor.c
+++ b/tools/json2cbor/json2cbor.c
@@ -23,6 +23,7 @@
 ****************************************************************************/
 
 #define _GNU_SOURCE
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
 #include "cbor.h"
 #include "cborinternal_p.h"
 #include "compilersupport_p.h"


### PR DESCRIPTION
Implement support for half-precision floating-point conversions using `_Float16` introduced in C11 extension ISO/IEC TS 18661-3.

Recent ARM compilers support _Float16.