### PR TITLE
Added possibility to include external config file.

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -34,6 +34,10 @@
 #include <string.h>
 #include <stdio.h>
 
+#ifdef CBOR_EXTERNAL_CFG
+#include "cbor_cfg.h"
+#endif
+
 #include "tinycbor-version.h"
 
 #define TINYCBOR_VERSION            ((TINYCBOR_VERSION_MAJOR << 16) | (TINYCBOR_VERSION_MINOR << 8) | TINYCBOR_VERSION_PATCH)


### PR DESCRIPTION
Currently I am working on a project where I have to define CBOR_PARSER_ADVANCE_BYTES_FUNCTION and CBOR_PARSER_TRANSFER_STRING_FUNCTION macros. Unfortunately the library doesn't include any external config file and building system I am using provides only possibility to add simple preprocessor definitions (like definition = value) on building script level. Adding macros is not possible. For this reason I am asking if we can add above change - if I add simple definition CBOR_EXTERNAL_CFG by build system then cbor will require cbor_cfg.h file where I can add needed macros.