### PR TITLE
Use internal linkage for data.cpp files

### DIFF
--- a/tests/encoder/data.cpp
+++ b/tests/encoder/data.cpp
@@ -24,7 +24,29 @@
 
 #include <QtTest>
 
-static float myNaNf()
+struct NegativeInteger { quint64 abs; };
+Q_DECLARE_METATYPE(NegativeInteger)
+
+struct SimpleType { uint8_t type; };
+Q_DECLARE_METATYPE(SimpleType)
+
+struct Float16Standin { uint16_t val; };
+Q_DECLARE_METATYPE(Float16Standin)
+
+struct Tag { CborTag tag; QVariant tagged; };
+Q_DECLARE_METATYPE(Tag)
+
+typedef QVector<QPair<QVariant, QVariant>> Map;
+Q_DECLARE_METATYPE(Map)
+
+struct IndeterminateLengthArray : QVariantList { using QVariantList::QVariantList; };
+struct IndeterminateLengthMap : Map { using Map::Map; };
+Q_DECLARE_METATYPE(IndeterminateLengthArray)
+Q_DECLARE_METATYPE(IndeterminateLengthMap)
+
+namespace {
+
+float myNaNf()
 {
     uint32_t v = 0x7fc00000;
     float f;
@@ -33,7 +55,7 @@ static float myNaNf()
     return f;
 }
 
-static float myInff()
+float myInff()
 {
     uint32_t v = 0x7f800000;
     float f;
@@ -42,7 +64,7 @@ static float myInff()
     return f;
 }
 
-static float myNInff()
+float myNInff()
 {
     uint32_t v = 0xff800000;
     float f;
@@ -51,7 +73,7 @@ static float myNInff()
     return f;
 }
 
-static double myNaN()
+double myNaN()
 {
     uint64_t v = UINT64_C(0x7ff8000000000000);
     double f;
@@ -60,7 +82,7 @@ static double myNaN()
     return f;
 }
 
-static double myInf()
+double myInf()
 {
     uint64_t v = UINT64_C(0x7ff0000000000000);
     double f;
@@ -69,7 +91,7 @@ static double myInf()
     return f;
 }
 
-static double myNInf()
+double myNInf()
 {
     uint64_t v = UINT64_C(0xfff0000000000000);
     double f;
@@ -83,35 +105,16 @@ template <size_t N> QByteArray raw(const char (&data)[N])
     return QByteArray::fromRawData(data, N - 1);
 }
 
-struct NegativeInteger { quint64 abs; };
-Q_DECLARE_METATYPE(NegativeInteger)
-
-struct SimpleType { uint8_t type; };
-Q_DECLARE_METATYPE(SimpleType)
-
-struct Float16Standin { uint16_t val; };
-Q_DECLARE_METATYPE(Float16Standin)
-
-struct Tag { CborTag tag; QVariant tagged; };
-Q_DECLARE_METATYPE(Tag)
-
 template <typename... Args>
 QVariant make_list(const Args &... args)
 {
     return QVariantList{args...};
 }
 
-typedef QVector<QPair<QVariant, QVariant>> Map;
-Q_DECLARE_METATYPE(Map)
 QVariant make_map(const std::initializer_list<QPair<QVariant, QVariant>> &list)
 {
     return QVariant::fromValue(Map(list));
 }
-
-struct IndeterminateLengthArray : QVariantList { using QVariantList::QVariantList; };
-struct IndeterminateLengthMap : Map { using Map::Map; };
-Q_DECLARE_METATYPE(IndeterminateLengthArray)
-Q_DECLARE_METATYPE(IndeterminateLengthMap)
 
 QVariant make_ilarray(const std::initializer_list<QVariant> &list)
 {
@@ -343,4 +346,4 @@ void addArraysAndMaps()
     QTest::newRow("array-1(map)") << raw("\x81\xc1\xa0") << make_list(QVariant::fromValue(Tag{1, make_map({})}));
     QTest::newRow("map-1(2):3(4)") << raw("\xa1\xc1\2\xc3\4") << make_map({{QVariant::fromValue(Tag{1, 2}), QVariant::fromValue(Tag{3, 4})}});
 }
-
+} // namespace

--- a/tests/parser/data.cpp
+++ b/tests/parser/data.cpp
@@ -28,6 +28,8 @@
 
 Q_DECLARE_METATYPE(CborError)
 
+namespace {
+
 template <size_t N> QByteArray raw(const char (&data)[N])
 {
     return QByteArray::fromRawData(data, N - 1);
@@ -605,3 +607,4 @@ void addValidationData(size_t minInvalid = ~size_t(0))
     // This test technically tests the dumper, not the parser.
     QTest::newRow("string-utf8-chunk-split") << raw("\x81\x7f\x61\xc2\x61\xa0\xff") << 0 << CborErrorInvalidUtf8TextString;
 }
+} // namespace


### PR DESCRIPTION
The Qt uses test batching and potentially encoder/data.cpp and parser/data.cpp can end up in the same translation unit. This can be problematic as they declare symbols with the same names.
Change both files to use internal linkage in order to avoid symbols clashing.