### PR TITLE
Add C90 bool support

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -45,7 +45,17 @@
 #ifdef __cplusplus
 extern "C" {
 #else
-#include <stdbool.h>
+#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#  include <stdbool.h>
+#else
+   typedef int bool;
+#  ifndef true
+#    define true 1
+#  endif
+#  ifndef false
+#    define false 0
+#  endif
+#endif
 #endif
 
 #ifndef SIZE_MAX

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -41,7 +41,17 @@
 #include <string.h>
 
 #ifndef __cplusplus
-#  include <stdbool.h>
+#  if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#    include <stdbool.h>
+#  else
+     typedef int bool;
+#    ifndef true
+#      define true 1
+#    endif
+#    ifndef false
+#      define false 0
+#    endif
+#  endif
 #endif
 
 #if __STDC_VERSION__ >= 201112L || (defined(__cplusplus) && __cplusplus >= 201103L) || (defined(__cpp_static_assert) && __cpp_static_assert >= 200410)


### PR DESCRIPTION
The bool datatype was added in C99,
so make a typedef for pre-C99 versions
of C, and define true/false.