### PR TITLE
follow-up commit to 75eaa19

### DIFF
--- a/src/cborparser_dup_string.c
+++ b/src/cborparser_dup_string.c
@@ -35,14 +35,8 @@
 
 #include "cbor.h"
 #include "compilersupport_p.h"
+#include "memory.h"
 
-#if defined(CBOR_CUSTOM_ALLOC_INCLUDE)
-#  include CBOR_CUSTOM_ALLOC_INCLUDE
-#else
-#  include <stdlib.h>
-#  define cbor_malloc malloc
-#  define cbor_free   free
-#endif
 
 /**
  * \fn CborError cbor_value_dup_text_string(const CborValue *value, char **buffer, size_t *buflen, CborValue *next)

--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -35,6 +35,7 @@
 #include "cborinternal_p.h"
 #include "compilersupport_p.h"
 #include "cborinternal_p.h"
+#include <memory.h>
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -179,7 +180,7 @@ static CborError dump_bytestring_base16(char **result, CborValue *it)
         return err;
 
     /* a Base16 (hex) output is twice as big as our buffer */
-    buffer = (uint8_t *)malloc(n * 2 + 1);
+    buffer = (uint8_t *)cbor_malloc(n * 2 + 1);
     if (buffer == NULL)
         /* out of memory */
         return CborErrorOutOfMemory;
@@ -209,7 +210,7 @@ static CborError generic_dump_base64(char **result, CborValue *it, const char al
 
     /* a Base64 output (untruncated) has 4 bytes for every 3 in the input */
     size_t len = (n + 5) / 3 * 4;
-    buffer = (uint8_t *)malloc(len + 1);
+    buffer = (uint8_t *)cbor_malloc(len + 1);
     if (buffer == NULL)
         /* out of memory */
         return CborErrorOutOfMemory;
@@ -395,7 +396,7 @@ static CborError tagged_value_to_json(FILE *out, CborValue *it, int flags, Conve
         if (err)
             return err;
         err = fprintf(out, "\"%s%s\"", pre, str) < 0 ? CborErrorIO : CborNoError;
-        free(str);
+        cbor_free(str);
         status->flags = TypeWasNotNative | TypeWasTagged | CborByteStringType;
         return err;
     }
@@ -467,7 +468,7 @@ static CborError map_to_json(FILE *out, CborValue *it, int flags, ConversionStat
 
         /* first, print the key */
         if (fprintf(out, "\"%s\":", key) < 0) {
-            free(key);
+            cbor_free(key);
             return CborErrorIO;
         }
 
@@ -489,7 +490,7 @@ static CborError map_to_json(FILE *out, CborValue *it, int flags, ConversionStat
             }
         }
 
-        free(key);
+        cbor_free(key);
         if (err)
             return err;
     }
@@ -568,7 +569,7 @@ static CborError value_to_json(FILE *out, CborValue *it, int flags, CborType typ
         if (err)
             return err;
         err = (fprintf(out, "\"%s\"", str) < 0) ? CborErrorIO : CborNoError;
-        free(str);
+        cbor_free(str);
         return err;
     }
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,0 +1,31 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Intel Corporation
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+** THE SOFTWARE.
+**
+****************************************************************************/
+
+#if defined(CBOR_CUSTOM_ALLOC_INCLUDE)
+#  include CBOR_CUSTOM_ALLOC_INCLUDE
+#else
+#  include <stdlib.h>
+#  define cbor_malloc malloc
+#  define cbor_free   free
+#endif


### PR DESCRIPTION
facilitate replacement of malloc/free functions

open_memstream functions are left out of this change as they require other functions from stdlib.