### PR TITLE
Corrected syntax error in `examples/simplereader.c`

### DIFF
--- a/examples/simplereader.c
+++ b/examples/simplereader.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 
     if (err) {
         fprintf(stderr, "CBOR parsing failure at offset %ld: %s\n",
-                it.ptr - buf, cbor_error_string(err));
+                it.source.ptr - buf, cbor_error_string(err));
         return 1;
     }
     return 0;

--- a/examples/simplereader.c
+++ b/examples/simplereader.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 
     if (err) {
         fprintf(stderr, "CBOR parsing failure at offset %ld: %s\n",
-                it.source.ptr - buf, cbor_error_string(err));
+                cbor_value_get_next_byte(&it) - buf, cbor_error_string(err));
         return 1;
     }
     return 0;


### PR DESCRIPTION
When compiling `simplereader.c`, following error is generated.
```
simplereader.c: In function ‘main’:
simplereader.c:181:19: error: ‘CborValue’ has no member named ‘ptr’
  181 |                 it.ptr - buf, cbor_error_string(err));
      |                   ^
```
As shown below, member of `struct CborParser` has been slightly changed in commit [34c8452](https://github.com/intel/tinycbor/commit/34c84520a764dfe5bac6725aa95e9871baf0bbc6)
```diff
 struct CborValue
 {
     const CborParser *parser;
-    const uint8_t *ptr;
+    union {
+        const uint8_t *ptr;
+        void *token;
+    } source;
     uint32_t remaining;
     uint16_t extra;
     uint8_t type;
@@ -298,13 +319,14 @@ typedef struct CborValue CborValue;
```
Therefore, replacing `it.ptr` with `it.source.ptr` will fix the error.