### PR TITLE
compilersupport_p.h: add a macro for the fallthrough attribute

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -231,7 +231,7 @@ static CborError preparse_value(CborValue *it)
         case SinglePrecisionFloat:
         case DoublePrecisionFloat:
             it->flags |= CborIteratorFlag_IntegerValueTooLarge;
-            /* fall through */
+            CBOR_FALLTHROUGH;
         case TrueValue:
         case NullValue:
         case UndefinedValue:

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -51,6 +51,20 @@
 #else
 #  define cbor_static_assert(x)         ((void)sizeof(char[2*!!(x) - 1]))
 #endif
+
+#if defined(__has_cpp_attribute)    // C23 and C++17
+#  if __has_cpp_attribute(fallthrough)
+#    define CBOR_FALLTHROUGH            [[fallthrough]]
+#  endif
+#endif
+#ifndef CBOR_FALLTHROUGH
+#  ifdef __GNUC__
+#    define CBOR_FALLTHROUGH            __attribute__((fallthrough))
+#  else
+#    define CBOR_FALLTHROUGH            do { } while (0)
+#  endif
+#endif
+
 #if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || defined(__cplusplus)
 /* inline is a keyword */
 #else


### PR DESCRIPTION
The `/* fallthrough */` comment isn't always handled, causing some compilers to complain about falling through.