### PR TITLE
AppVeyor: replace Qt 5.13+MSVC 2017 with Qt 6.8+MSVC 2022

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,13 +2,13 @@ version: 0.6-build-{build}
 pull_requests:
   do_not_increment_build_number: true
 image:
-- Visual Studio 2017
 - Visual Studio 2019
+- Visual Studio 2022
 install:
 - cmd: >-
-    if /i "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86) & (set QTDIR=C:\Qt\5.13\msvc2017)
-
     if /i "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64) & (set QTDIR=C:\Qt\6.5\msvc2019_64)
+
+    if /i "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" (call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat") & (set QTDIR=C:\Qt\6.8\msvc2022_64)
 
     set path=%PATH%;%QTDIR%\bin
 build_script:


### PR DESCRIPTION
MSVC 2017 is way too old now.