### PR TITLE
tst_Parser: replace Q_ASSERT(false) with Q_UNREACHABLE()

### DIFF
--- a/tests/parser/tst_parser.cpp
+++ b/tests/parser/tst_parser.cpp
@@ -258,7 +258,7 @@ CborError parseOneChunk(CborValue *it, QString *parsed)
         if (text)
             *parsed = '"' + QString::fromUtf8(text, len) + '"';
     } else {
-        Q_ASSERT(false);
+        Q_UNREACHABLE();
     }
     return err;
 }


### PR DESCRIPTION
`Q_ASSERT()` disappears in release mode, leading Clang to print a static analysis warning about an impossible condition:
```
tst_parser.cpp:251:16: warning: variable 'err' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
  251 |     } else if (ourType == CborTextStringType) {
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tst_parser.cpp:263:12: note: uninitialized use occurs here
  263 |     return err;
      |            ^~~
tst_parser.cpp:251:12: note: remove the 'if' if its condition is always true
```

`Q_UNREACHABLE()` becomes a plain `__builtin_unreachable()` in release mode.