### PR TITLE
CBOR-to-JSON: do properly escape JSON strings

### DIFF
--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -234,4 +234,15 @@ static inline bool add_check_overflow(size_t v1, size_t v2, size_t *r)
 #endif
 }
 
+static inline bool mul_check_overflow(size_t v1, size_t v2, size_t *r)
+{
+#if ((defined(__GNUC__) && (__GNUC__ >= 5)) && !defined(__INTEL_COMPILER)) || __has_builtin(__builtin_add_overflow)
+    return __builtin_mul_overflow(v1, v2, r);
+#else
+    /* unsigned multiplications are well-defined */
+    *r = v1 * v2;
+    return *r > v1 && *r > v2;
+#endif
+}
+
 #endif /* COMPILERSUPPORT_H */

--- a/src/memory.h
+++ b/src/memory.h
@@ -26,6 +26,7 @@
 #  include CBOR_CUSTOM_ALLOC_INCLUDE
 #else
 #  include <stdlib.h>
-#  define cbor_malloc malloc
-#  define cbor_free   free
+#  define cbor_malloc   malloc
+#  define cbor_realloc  realloc
+#  define cbor_free     free
 #endif

--- a/tests/tojson/tst_tojson.cpp
+++ b/tests/tojson/tst_tojson.cpp
@@ -160,6 +160,18 @@ void addTextStringsData()
     QTest::newRow("_textstring5*2") << raw("\x7f\x63Hel\x62lo\xff") << "\"Hello\"";
     QTest::newRow("_textstring5*5") << raw("\x7f\x61H\x61""e\x61l\x61l\x61o\xff") << "\"Hello\"";
     QTest::newRow("_textstring5*6") << raw("\x7f\x61H\x61""e\x61l\x60\x61l\x61o\xff") << "\"Hello\"";
+
+    // strings containing characters that are escaped in JSON
+    QTest::newRow("null") << raw("\x61\0") << R"("\u0000")";
+    QTest::newRow("bell") << raw("\x61\7") << R"("\u0007")";    // not \\a
+    QTest::newRow("backspace") << raw("\x61\b") << R"("\b")";
+    QTest::newRow("tab") << raw("\x61\t") << R"("\t")";
+    QTest::newRow("carriage-return") << raw("\x61\r") << R"("\r")";
+    QTest::newRow("line-feed") << raw("\x61\n") << R"("\n")";
+    QTest::newRow("form-feed") << raw("\x61\f") << R"("\f")";
+    QTest::newRow("esc") << raw("\x61\x1f") << R"("\u001f")";
+    QTest::newRow("quote") << raw("\x61\"") << R"("\"")";
+    QTest::newRow("backslash") << raw("\x61\\") << R"("\\")";
 }
 
 void addNonJsonData()
@@ -412,6 +424,15 @@ void tst_ToJson::nonStringKeyMaps_data()
     QTest::newRow("map-24-0") << raw("\xa1\x18\x18\0") << "{24: 0}";
     QTest::newRow("_map-0-24") << raw("\xbf\0\x18\x18\xff") << "{_ 0: 24}";
     QTest::newRow("_map-24-0") << raw("\xbf\x18\x18\0\xff") << "{_ 24: 0}";
+
+    // nested strings ought to be escaped
+    QTest::newRow("array-emptystring") << raw("\x81\x60") << R"([\"\"])";
+    QTest::newRow("array-string1") << raw("\x81\x61 ") << R"([\" \"])";
+
+    // and escaped chracters in strings end up doubly escaped
+    QTest::newRow("array-string-null") << raw("\x81\x61\0") << R"([\"\\u0000\"])";
+    QTest::newRow("array-string-quote") << raw("\x81\x61\"") << R"([\"\\\"\"])";
+    QTest::newRow("array-string-backslash") << raw("\x81\x61\\") << R"([\"\\\\\"])";
 }
 
 void tst_ToJson::nonStringKeyMaps()


### PR DESCRIPTION
We hadn't bothered, as this was just example-like code to show how one could convert from CBOR to JSON. But as it was added to the library (no extra dependency), we should Do The Right Thing (DTRT) and escape.

This patch could have used `cbor_value_to_pretty()` to print the string, which has better support for UTF-8 escaping and thus checks for UTF-8 correctness, but that would make `map_to_json()`'s metadata functionality much more complex, especially since we cannot rely on `open_memstream()` always being available. Therefore, we are partially duplicating cborpretty.c's `utf8EscapedDump()`.