### PR TITLE
Always init CborEncoder::data in cbor_encoder_init_writer()

### DIFF
--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -213,6 +213,7 @@ void cbor_encoder_init_writer(CborEncoder *encoder, CborEncoderWriteFunction wri
 {
 #ifdef CBOR_ENCODER_WRITE_FUNCTION
     (void) writer;
+    encoder->data.writer = CBOR_NULLPTR;
 #else
     encoder->data.writer = writer;
 #endif

--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -198,9 +198,11 @@
 
 #ifdef __cplusplus
 #  define CONST_CAST(t, v)  const_cast<t>(v)
+#  define CBOR_NULLPTR nullptr
 #else
 /* C-style const_cast without triggering a warning with -Wcast-qual */
 #  define CONST_CAST(t, v)  (t)(uintptr_t)(v)
+#  define CBOR_NULLPTR NULL
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
Coverity complains that, when CBOR_ENCODER_WRITE_FUNCTION is defined, enc.data is read in cbor_encoder_create_map() when cbor_encoder_init_writer() didn't write to it.

While 'data' is merely copied in cbor_encoder_create_map(), Coverity is right, though: reading an uninitialized value is UB.

Fix by setting data.writer to nullptr (abstracting the difference between C and C++ behind a new macro).