### PR TITLE
CBOR-to-JSON: fix UB in converting out-of-bounds FP to integer

### DIFF
--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -744,8 +744,10 @@ static CborError value_to_json(FILE *out, CborValue *it, int flags, CborType typ
             status->flags |= r == FP_NAN ? NumberWasNaN :
                                            NumberWasInfinite | (val < 0 ? NumberWasNegative : 0);
         } else {
-            uint64_t ival = (uint64_t)fabs(val);
-            if ((double)ival == fabs(val)) {
+            const double limit = (UINT32_MAX + 1.0) * (UINT32_MAX + 1.0);  /* 2^64 */
+            uint64_t ival = 0;
+            double aval = fabs(val);
+            if (aval < limit && (double)(ival = (uint64_t)aval) == aval) {
                 /* print as integer so we get the full precision */
                 r = fprintf(out, "%s%" PRIu64, val < 0 ? "-" : "", ival);
                 status->flags |= TypeWasNotNative;   /* mark this integer number as a double */


### PR DESCRIPTION
Both the C and C++ standards say it is Undefined Behavior to convert a floating point number to integer if the input is out of bounds of the destination type.

And indeed this started failing in recent builds, with
  val = 18446744073709551616  (2^64)
it has probably been producing ival = 18446744073709551615 for a while, but the conversion back to floating point now rounded up and compared equal to the input.

So let's just fix it.