### PR TITLE
Pretty: fix Undefined Behavior with NaN floats

### DIFF
--- a/src/cborpretty.c
+++ b/src/cborpretty.c
@@ -164,7 +164,7 @@ static inline bool convertToUint64(double v, uint64_t *absolute)
      *    value, chosen in an implementation-defined manner.
      */
     supremum = -2.0 * INT64_MIN;     /* -2 * (- 2^63) == 2^64 */
-    if (v >= supremum)
+    if (!(v < supremum)) /* out of range or NaN */
         return false;
 
     /* Now we can convert, these two conversions cannot be UB */


### PR DESCRIPTION
When printing CBOR data containing NaN, function `convertToUint64` does an undefined behavior. This can be reproduced using test cases from `tests/parser/data.cpp`:

```console
$ make CC='clang -fsanitize=undefined'
$ printf "\xfb\x7f\xf8\0\0\0\0\0\0" | ./bin/cbordump
src/cborpretty.c:171:17: runtime error: nan is outside the range of representable values of type 'unsigned long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/cborpretty.c:171:17 in
nan

$ printf "\xf9\x7e\x00" | ./bin/cbordump
src/cborpretty.c:171:17: runtime error: nan is outside the range of representable values of type 'unsigned long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/cborpretty.c:171:17 in
nan
```

Fix this by checking whether the value to convert is not NaN.