### PR TITLE
CI: switch to using CMake

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.6-build-{build}
+version: build-{build}
 pull_requests:
   do_not_increment_build_number: true
 image:
@@ -13,16 +13,18 @@ install:
     set path=%PATH%;%QTDIR%\bin
 build_script:
 - cmd: >-
-    nmake -f Makefile.nmake -nologo CFLAGS="-W3 -Os -MDd"
+    cmake -S. -Bbuild -GNinja -DWITH_CBOR2JSON=OFF -DBUILD_TESTING=ON -DCMAKE_C_FLAGS="-W3 -Os -MDd" -DCMAKE_CXX_FLAGS="-W3 -O2 -MDd"
 
-    cd tests
+    ninja -C build
 
-    qmake CONFIG-=release CONFIG+=debug
-
-    nmake -nologo -s
 test_script:
 - cmd: >-
-    nmake -s -nologo TESTARGS=-silent check
+    ctest --test-dir build --output-on-failure --output-junit ctest.junitxml
+
+after_test:
+- cmd: >-
+    curl -F file=@build/ctest.junitxml https://ci.appveyor.com/api/testresults/junit/%APPVEYOR_JOB_ID%
+
 artifacts:
-- path: lib\tinycbor.lib
+#- path: build\tinycbor.lib
 deploy: off

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,29 +37,53 @@ jobs:
           cmakeflags: >-
             -DCMAKE_C_FLAGS="-Os -Werror"
             -DWITH_FREESTANDING=ON
+        - name: gcc-small
+          cmakeflags: >-
+            -DBUILD_TESTING=OFF
+            -DCMAKE_C_FLAGS="-Os -Werror"
+        - name: clang-small
+          cmakeflags: >-
+            -DBUILD_TESTING=OFF
+            -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_FLAGS="-Oz -g -Werror"
         - name: clang
           cmakeflags: >-
             -DBUILD_SHARED_LIBS=ON
+            -DCMAKE_BUILD_TYPE=Debug
             -DCMAKE_C_COMPILER=clang
-            -DCMAKE_C_FLAGS="-Oz -g -Werror"
+            -DCMAKE_C_FLAGS_DEBUG="-Werror"
             -DCMAKE_CXX_COMPILER=clang++
-            -DCMAKE_CXX_FLAGS="-O2 -g -Werror"
+            -DCMAKE_CXX_FLAGS_DEBUG="-Werror"
         - name: linux-g++
           cmakeflags: >-
             -DBUILD_SHARED_LIBS=ON
+            -DCMAKE_BUILD_TYPE=Debug
             -DCMAKE_C_COMPILER=gcc
-            -DCMAKE_C_FLAGS="-Os -g -Werror"
+            -DCMAKE_C_FLAGS_DEBUG="-Werror"
             -DCMAKE_CXX_COMPILER=g++
-            -DCMAKE_CXX_FLAGS="-O2 -g -Werror"
+            -DCMAKE_CXX_FLAGS_DEBUG="-Werror"
         include:
         - os: macos-13
           build_cfg:
-            name: clang
+            name: clang-small
             cmakeflags: >-
+              -DBUILD_TESTING=OFF
               -DCMAKE_C_COMPILER=clang
               -DCMAKE_C_FLAGS="-Oz -g -Werror"
               -DCMAKE_CXX_COMPILER=clang++
               -DCMAKE_CXX_FLAGS="-O2 -g -Werror"
+        - os: macos-13
+          build_cfg:
+            name: clang
+            cmakeflags: >-
+              -DBUILD_SHARED_LIBS=ON
+              -DCMAKE_BUILD_TYPE=Debug
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_C_FLAGS_DEBUG="-Werror -fsanitize=address"
+              -DCMAKE_CXX_COMPILER=clang++
+              -DCMAKE_CXX_FLAGS_DEBUG="-Werror -fsanitize=address"
+              -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
+              -DCMAKE_MODULE_LINKER_FLAGS="-fsanitize=address"
 
 
     # Default job name is too long to be visible in the "Checks" tab.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,59 +27,40 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        build_cfg: [
-          { "name": "gcc-no-math",
-            "flags":
-              '{ "QMAKESPEC": "linux-gcc-no-math",
-                 "EVAL": "export CXX=false && touch math.h float.h",
-                 "CFLAGS": "-ffreestanding -DCBOR_NO_FLOATING_POINT -Os",
-                 "LDFLAGS": "-Wl,--no-undefined",
-                 "LDLIBS": ""
-              }',
-          },
-          { "name": "gcc-freestanding",
-            "flags":
-              '{ "QMAKESPEC": "linux-gcc-freestanding",
-                 "EVAL": "export CXX=false",
-                 "CFLAGS": "-ffreestanding -Os",
-                 "LDFLAGS": "-Wl,--no-undefined -lm"
-              }',
-          },
-          { "name": "clang",
-            "flags":
-              '{ "QMAKESPEC": "linux-clang",
-                 "EVAL": "export CC=clang && export CXX=clang++",
-                 "CFLAGS": "-Oz",
-                 "LDFLAGS": "-Wl,--no-undefined -lm",
-                 "QMAKEFLAGS": "-config release",
-                 "MAKEFLAGS": "-s",
-                 "TESTARGS": "-silent"
-              }',
-          },
-          { "name": "linux-g++",
-            "flags":
-              '{ "QMAKESPEC": "linux-g++",
-                 "EVAL": "export CC=gcc && export CXX=g++",
-                 "CFLAGS": "-Os",
-                 "LDFLAGS": "-Wl,--no-undefined -lm",
-                 "QMAKEFLAGS": "-config release",
-                 "QT_NO_CPU_FEATURE": "rdrnd"
-              }'
-          }
-        ]
+        build_cfg:
+        - name: gcc-no-math
+          cmakeflags: >-
+            -DCMAKE_C_FLAGS="-Os"
+            -DWITH_FLOATING_POINT=OFF
+            -DWITH_FREESTANDING=ON
+        - name: gcc-freestanding
+          cmakeflags: >-
+            -DCMAKE_C_FLAGS="-Os"
+            -DWITH_FREESTANDING=ON
+        - name: clang
+          cmakeflags: >-
+            -DBUILD_SHARED_LIBS=ON
+            -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_FLAGS="-Oz -g"
+            -DCMAKE_CXX_COMPILER=clang++
+            -DCMAKE_CXX_FLAGS="-O2 -g"
+        - name: linux-g++
+          cmakeflags: >-
+            -DBUILD_SHARED_LIBS=ON
+            -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_FLAGS="-Os -g"
+            -DCMAKE_CXX_COMPILER=g++
+            -DCMAKE_CXX_FLAGS="-O2 -g"
         include:
-          - os: macos-13
-            build_cfg: { "name": "clang",
-                         "flags":
-                           '{ "QMAKESPEC": "macx-clang",
-                              "EVAL": "export CC=clang && export CXX=clang++",
-                              "CFLAGS": "-Oz",
-                              "QMAKEFLAGS": "-config debug",
-                              "MAKEFLAGS": "-s",
-                              "TESTARGS": "-silent",
-                              "PATH": "/usr/local/opt/qt/bin:$PATH"
-                            }'
-                        }
+        - os: macos-13
+          build_cfg:
+            name: clang
+            cmakeflags: >-
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_C_FLAGS="-Oz -g"
+              -DCMAKE_CXX_COMPILER=clang++
+              -DCMAKE_CXX_FLAGS="-O2 -g"
+
 
     # Default job name is too long to be visible in the "Checks" tab.
     name: ${{ matrix.os }}/${{ matrix.build_cfg.name }}
@@ -97,44 +78,36 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           doxygen \
-          jq \
+          cmake \
           libc6-dbg \
           libcjson-dev \
           libfuntools-dev \
-          qtbase5-dev
+          ninja-build \
+          qt6-base-dev
 
     - name: install macOS software
       if: runner.os == 'macOS'
       run: |
-        # Doxygen 1.9.7 is broken with ifdefs again, install 1.9.4 which works.
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/41828ee36b96e35b63b2a4c8cfc2df2c3728944a/Formula/doxygen.rb
-        brew install doxygen.rb
-        rm doxygen.rb
-        brew install qt cjson
+        brew install -q \
+             cjson \
+             cmake \
+             ninja \
+             qt
+
+    - name: Compile
+      run: |
+        set -x
+        cmake -S. -Bbuild -GNinja -DBUILD_TESTING=ON \
+              ${{ matrix.build_cfg.cmakeflags }}
+        ninja -C build -v
+        if [[ -f build/libtinycbor.a ]]; then
+            size build/libtinycbor.a | tee sizes
+        fi
 
     - name: Execute tests
       run: |
-        set -x
-        PATH=`echo /opt/qt*/bin`:$PATH
-        eval $(echo '${{ matrix.build_cfg.flags }}' | jq -r 'to_entries[] | "\(.key)=\"\(.value)\""')
-        eval "$EVAL"
-        # FIXME: remove -Wno-error-line below.
-        export CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
-        make OUT=.config V=1 -s -f Makefile.configure configure && cat .config
-        make -k \
-            CFLAGS="$CFLAGS -march=native -g1 -Wall -Wextra -Werror" \
-            CPPFLAGS="-DNDEBUG -DCBOR_ENCODER_WRITER_CONTROL=-1 -DCBOR_PARSER_READER_CONTROL=-1" \
-            lib/libtinycbor.a
-        size lib/libtinycbor.a | tee sizes
-        make -s clean
-        make -k \
-            CFLAGS="$CFLAGS -O0 -g" \
-            LDFLAGS="$LDFLAGS" ${LDLIBS+LDLIBS="$LDLIBS"}
-        grep -q freestanding-pass .config || make \
-            QMAKEFLAGS="$QMAKEFLAGS QMAKE_CXX=$CXX" \
-            tests/Makefile
-        grep -q freestanding-pass .config || \
-            (cd tests && make TESTARGS=-silent check -k \
-            TESTRUNNER=`which valgrind 2>/dev/null`)
-        make -s clean
-        ! [ $BUILD_DOCS ] || ./scripts/update-docs.sh
+        ctest --output-on-failure --test-dir build
+
+    - name: Build docs
+      if: matrix.build_cfg.docs
+      run: ./scripts/update-docs.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,36 +30,36 @@ jobs:
         build_cfg:
         - name: gcc-no-math
           cmakeflags: >-
-            -DCMAKE_C_FLAGS="-Os"
+            -DCMAKE_C_FLAGS="-Os -Werror"
             -DWITH_FLOATING_POINT=OFF
             -DWITH_FREESTANDING=ON
         - name: gcc-freestanding
           cmakeflags: >-
-            -DCMAKE_C_FLAGS="-Os"
+            -DCMAKE_C_FLAGS="-Os -Werror"
             -DWITH_FREESTANDING=ON
         - name: clang
           cmakeflags: >-
             -DBUILD_SHARED_LIBS=ON
             -DCMAKE_C_COMPILER=clang
-            -DCMAKE_C_FLAGS="-Oz -g"
+            -DCMAKE_C_FLAGS="-Oz -g -Werror"
             -DCMAKE_CXX_COMPILER=clang++
-            -DCMAKE_CXX_FLAGS="-O2 -g"
+            -DCMAKE_CXX_FLAGS="-O2 -g -Werror"
         - name: linux-g++
           cmakeflags: >-
             -DBUILD_SHARED_LIBS=ON
             -DCMAKE_C_COMPILER=gcc
-            -DCMAKE_C_FLAGS="-Os -g"
+            -DCMAKE_C_FLAGS="-Os -g -Werror"
             -DCMAKE_CXX_COMPILER=g++
-            -DCMAKE_CXX_FLAGS="-O2 -g"
+            -DCMAKE_CXX_FLAGS="-O2 -g -Werror"
         include:
         - os: macos-13
           build_cfg:
             name: clang
             cmakeflags: >-
               -DCMAKE_C_COMPILER=clang
-              -DCMAKE_C_FLAGS="-Oz -g"
+              -DCMAKE_C_FLAGS="-Oz -g -Werror"
               -DCMAKE_CXX_COMPILER=clang++
-              -DCMAKE_CXX_FLAGS="-O2 -g"
+              -DCMAKE_CXX_FLAGS="-O2 -g -Werror"
 
 
     # Default job name is too long to be visible in the "Checks" tab.


### PR DESCRIPTION
This switches the GitHub Actions and AppVeyor CIs to using the CMake build instead of the old Makefile/qmake hybrid.

New features:
* Compiles with `-Wall -Wextra -Werror`
* Compiles using the Address Sanitizer on macOS
* Compiles the testing runs using shared libraries instead of static