### PR TITLE
simplereader: Fix warning about use of pointer variable after free()

### DIFF
--- a/examples/simplereader.c
+++ b/examples/simplereader.c
@@ -174,12 +174,13 @@ int main(int argc, char **argv)
     CborError err = cbor_parser_init(buf, length, 0, &parser, &it);
     if (!err)
         err = dumprecursive(&it, 0);
-    free(buf);
 
     if (err) {
         fprintf(stderr, "CBOR parsing failure at offset %ld: %s\n",
                 cbor_value_get_next_byte(&it) - buf, cbor_error_string(err));
+        free(buf);
         return 1;
     }
+    free(buf);
     return 0;
 }


### PR DESCRIPTION
We weren't dereferencing the variable, so this should have been safe. However, it isn't clear in the C and C++ standards whether it legitimately was safe. So let's just fix it.

```
simplereader.c:180:9: warning: pointer ‘buf’ may be used after ‘free’ [-Wuse-after-free]
simplereader.c:177:5: note: call to ‘free’ here
```