### PR TITLE
Fix build with GCC < 11: [[fallthrough]] is supported but not allowed in C

### DIFF
--- a/src/compilersupport_p.h
+++ b/src/compilersupport_p.h
@@ -52,8 +52,12 @@
 #  define cbor_static_assert(x)         ((void)sizeof(char[2*!!(x) - 1]))
 #endif
 
-#if defined(__has_cpp_attribute)    // C23 and C++17
+#if defined(__has_cpp_attribute) && defined(__cplusplus)    // C++17
 #  if __has_cpp_attribute(fallthrough)
+#    define CBOR_FALLTHROUGH            [[fallthrough]]
+#  endif
+#elif defined(__has_c_attribute) && !defined(__cplusplus)   // C23
+#  if __has_c_attribute(fallthrough)
 #    define CBOR_FALLTHROUGH            [[fallthrough]]
 #  endif
 #endif


### PR DESCRIPTION
I think GCC says `__has_cpp_attribute(fallthrough)` is true because C++ supports it (it means "has C++ attribute"), but that doesn't apply to the C language. This causes a compilation error:

```
compilersupport_p.h:57:41: error: expected expression before '[' token
   57 | #    define CBOR_FALLTHROUGH            [[fallthrough]]
      |                                         ^
cborparser.c:225:13: note: in expansion of macro 'CBOR_FALLTHROUGH'
  225 |             CBOR_FALLTHROUGH;
      |             ^~~~~~~~~~~~~~~~
```

Instead, we should use the C23 `__has_c_attribute` to detect the C attribute.


Fixes #293.