### PR TITLE
Fetchcontent frendly CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ cmake_minimum_required(VERSION 3.10)
 project(tinycbor LANGUAGES C CXX VERSION 7.0)
 
 # Set path to additional cmake scripts
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 set(TARGETS_EXPORT_NAME "TinyCBOR-targets")
 
@@ -142,14 +142,14 @@ endif()
 
 target_include_directories(tinycbor
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
-  PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>"
+  PUBLIC "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
   PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
 install(FILES
-  src/cbor.h
-  ${CMAKE_BINARY_DIR}/tinycbor-version.h
-  ${CMAKE_BINARY_DIR}/tinycbor-export.h
+  ${PROJECT_SOURCE_DIR}/src/cbor.h
+  ${PROJECT_BINARY_DIR}/tinycbor-version.h
+  ${PROJECT_BINARY_DIR}/tinycbor-export.h
   TYPE INCLUDE
 )
 install(

--- a/cmake/PackageConfig.cmake
+++ b/cmake/PackageConfig.cmake
@@ -7,7 +7,7 @@
 include(CMakePackageConfigHelpers)
 
 configure_package_config_file(
-  "${CMAKE_SOURCE_DIR}/cmake/project-config.cmake.in"
+  "${PROJECT_SOURCE_DIR}/cmake/project-config.cmake.in"
   "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
   #PATH_VARS CMAKE_INSTALL_DIR


### PR DESCRIPTION
I changed CMakeLists.txt to enable `FetchContent` this library from the user library.

1. In the case of `cmake_source_dir`, there was an issue where it was overridden with the parent project path when building the library using `FetchContent`, causing it to not work properly. So I changed `cmake_source_dir` to `project_source_dir`.
2.  I remember the header install path is `tinycbor/cbor.h`, but has the installation path changed to `cbor.h`? If the `cbor.h` installation is only performed during the cmake install process, that part should also be fixed.