### PR TITLE
cbortojson: [CWE-401] fix memory leak when realloc() is fails

### DIFF
--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -329,9 +329,10 @@ static CborError escape_text_string(char **str, size_t *alloc, size_t *offsetp, 
         return CborErrorDataTooLarge;
     }
     if (!alloc || needed > *alloc) {
-        buf = cbor_realloc(buf, needed);
-        if (!buf)
+        char *tmp = cbor_realloc(buf, needed);
+        if (!tmp)
             return CborErrorOutOfMemory;
+        buf = tmp;
         if (alloc)
             *alloc = needed;
     }


### PR DESCRIPTION
@thiagomacieira, I accidentally found it while I was studying the source code.

It is better to close this possible leak before assign CVE id and score, and also protect yourself from possible attack vectors by intruders.

This commit also have identical issue as real CVE-2019-17178 vulnerability in FreeRDP project:

Fix commit - https://github.com/FreeRDP/FreeRDP/commit/9fee4ae076b1ec97b97efb79ece08d1dab4df29a

Issue - https://github.com/FreeRDP/FreeRDP/issues/5645

More info about CWE metrics:

https://cwe.mitre.org/data/definitions/401.html